### PR TITLE
Crisis support page

### DIFF
--- a/test/controllers/support_controller_test.exs
+++ b/test/controllers/support_controller_test.exs
@@ -3,6 +3,6 @@ defmodule Healthlocker.SupportControllerTest do
 
   test "GET /support", %{conn: conn} do
     conn = get conn, "/support"
-    assert html_response(conn, 200) =~ "Get Support"
+    assert html_response(conn, 200) =~ "What to do in a crisis"
   end
 end

--- a/test/controllers/support_controller_test.exs
+++ b/test/controllers/support_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule Healthlocker.SupportControllerTest do
+  use Healthlocker.ConnCase
+
+  test "GET /support", %{conn: conn} do
+    conn = get conn, "/support"
+    assert html_response(conn, 200) =~ "Get Support"
+  end
+end

--- a/test/views/support_view_test.exs
+++ b/test/views/support_view_test.exs
@@ -1,0 +1,3 @@
+defmodule Healthlocker.SupportViewTest do
+  use Healthlocker.ConnCase, async: true
+end

--- a/web/controllers/support_controller.ex
+++ b/web/controllers/support_controller.ex
@@ -1,0 +1,7 @@
+defmodule Healthlocker.SupportController do
+  use Healthlocker.Web, :controller
+
+  def index(conn, _params) do
+    render conn, "index.html"
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,6 +18,7 @@ defmodule Healthlocker.Router do
 
     get "/", PageController, :index
     resources "/posts", PostController, only: [:show, :new, :create, :index]
+    get "/support", SupportController, :index
   end
 
   # Other scopes may use custom stacks.

--- a/web/templates/support/index.html.eex
+++ b/web/templates/support/index.html.eex
@@ -1,3 +1,37 @@
-<div>
-  <h1>Get Support</h1>
+<div class ="ma3 ma4-m ma6-l mv2 mv3-m mv4-l">
+  <h4 class="tc">Get Support</h4>
+
+  <h5>What to do in a crisis</h5>
+  <p>If you need urgent help or advice: </p>
+  <div class="bg-black-10 pv3">
+    <div class="fl pv4 ph1 w3 ml4 mt2">
+      <img class="mw-100" src="https://cloud.githubusercontent.com/assets/1287388/22465297/e859151c-e7b2-11e6-9b23-fcd59b4c51ca.png" alt="phone-icon">
+    </div>
+    <div class="mh6">
+      <h5>SLaM crisis support</h5>
+      <p>24-hour mental health support line</p>
+      <a href="tel:08007312864">0800 731 2864</a>
+    </div>
+  </div>
+
+  <ul>
+    <li class="mb3 ml3 mr5">Follow your care plan, if you have one or call your care co-ordinator.</li>
+    <li class="mb3 ml3 mr5">If you feel unsafe and need immediate help <a href="tel:999">call 999</a> or <a href="http://www.nhs.uk/Service-Search/Accident-and-emergency-services/LocationSearch/428">find your nearest A&E</a>, open 24/7.</li>
+    <li class="mb3 ml3 mr5">If you can wait for an appointment, your GP can help you find the best service for you...</li>
+  </ul>
+
+  <div class="">
+    <h5>App support</h5>
+    <p>Something about problems on the website</p>
+  </div>
+
+  <div class="bg-black-10 pt3 pb4 mh0">
+    <div class="fl w3 ml4 mt3">
+      <img src="https://cloud.githubusercontent.com/assets/1287388/22470204/6a59808e-e7c6-11e6-82ef-b92478978281.png" alt="at symbol">
+    </div>
+    <div class="mh6">
+      <h5>Healthlocker support</h5>
+      <a href="mailto:itsupport@healthlocker.nhs.uk">itsupport@healthlocker.nhs.uk</a>
+    </div>
+  </div>
 </div>

--- a/web/templates/support/index.html.eex
+++ b/web/templates/support/index.html.eex
@@ -1,0 +1,3 @@
+<div>
+  <h1>Get Support</h1>
+</div>

--- a/web/views/post_view.ex
+++ b/web/views/post_view.ex
@@ -1,5 +1,3 @@
 defmodule Healthlocker.PostView do
   use Healthlocker.Web, :view
-
-  alias Healthlocker.Post
 end

--- a/web/views/support_view.ex
+++ b/web/views/support_view.ex
@@ -1,0 +1,3 @@
+defmodule Healthlocker.SupportView do
+  use Healthlocker.Web, :view
+end


### PR DESCRIPTION
Adds a static page displaying all the information for immediate crisis support.

The `Get Support` title may be integrated into a header/navbar

Section which will later need clarification for content is the `App support` section