### PR TITLE
Markdown

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule Healthlocker.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:earmark, "~> 1.1"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
+  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
   "ecto": {:hex, :ecto, "2.1.3", "ffb24e150b519a4c0e4c84f9eabc8587199389bc499195d5d1a93cd3b2d9a045", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "fs": {:hex, :fs, "2.12.0", "ad631efacc9a5683c8eaa1b274e24fa64a1b8eb30747e9595b93bec7e492e25e", [:rebar3], []},
   "gettext": {:hex, :gettext, "0.13.0", "daafbddc5cda12738bb93b01d84105fe75b916a302f1c50ab9fb066b95ec9db4", [:mix], []},

--- a/test/views/post_view_test.exs
+++ b/test/views/post_view_test.exs
@@ -1,0 +1,8 @@
+defmodule Healthlocker.PostViewTest do
+  use Healthlocker.ConnCase, async: true
+
+  test "converts markdown to html" do
+    {:safe, result} = Healthlocker.PostView.markdown("**Hello, world!**")
+    assert String.contains? result, "<strong>Hello, world!</strong>"
+  end
+end

--- a/web/templates/post/post.html.eex
+++ b/web/templates/post/post.html.eex
@@ -1,1 +1,1 @@
-<%= text_to_html @post.content %></p>
+<%= markdown @post.content %></p>

--- a/web/views/post_view.ex
+++ b/web/views/post_view.ex
@@ -1,5 +1,9 @@
 defmodule Healthlocker.PostView do
   use Healthlocker.Web, :view
 
-  alias Healthlocker.Post
+  def markdown(body) do
+    body
+    |> Earmark.as_html!
+    |> raw
+  end
 end


### PR DESCRIPTION
Use the [earmark](https://github.com/pragdave/earmark) library to convert markdown to HTML. Fixes #31 

### TODO 
- [ ] Escape HTML, to avoid XSS attacks.