### PR TITLE
Strategies clean up

### DIFF
--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -95,7 +95,7 @@ defmodule Healthlocker.UserControllerTest do
     }
     user = Repo.get_by(User, email: "me@example.com")
     conn = put conn, "/users/#{user.id}/#{:create3}", user: @step3_attrs
-    assert redirected_to(conn) == user_path(conn, :index)
+    assert redirected_to(conn) == toolkit_path(conn, :index)
   end
 
   test "does not update resource with data_access and renders errors when data is invalid", %{conn: conn} do

--- a/web/controllers/auth.ex
+++ b/web/controllers/auth.ex
@@ -11,7 +11,7 @@ defmodule Healthlocker.Auth do
     cond do
       user = conn.assigns[:current_user] ->
         conn
-      user = user_id && repo.get(Healthlocker.User, user_id) ->
+      user = user_id && repo.get(Healthlocker.User, user_id) |> repo.preload(:likes) ->
         assign(conn, :current_user, user)
       true ->
         assign(conn, :current_user, nil)
@@ -27,7 +27,7 @@ defmodule Healthlocker.Auth do
 
   def email_and_pass_login(conn, email, given_pass, opts) do
     repo = Keyword.fetch!(opts, :repo)
-    user = repo.get_by(Healthlocker.User, email: email)
+    user = repo.get_by(Healthlocker.User, email: email) |> repo.preload(:likes)
 
     cond do
       user && checkpw(given_pass, user.password_hash) ->

--- a/web/controllers/login_controller.ex
+++ b/web/controllers/login_controller.ex
@@ -10,7 +10,7 @@ defmodule Healthlocker.LoginController do
       {:ok, conn} ->
         conn
         |> put_flash(:info, "Welcome to Healthlocker!")
-        |> redirect(to: post_path(conn, :new))
+        |> redirect(to: toolkit_path(conn, :index))
       {:error, _reason, conn} ->
         conn
         |> put_flash(:error, "Invalid email/password combination")

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -59,13 +59,13 @@ defmodule Healthlocker.UserController do
   def create3(conn, %{"user" => user_params, "id" => id}) do
     user = Repo.get!(User, id)
     changeset = User.data_access(user, user_params)
-    
+
     case Repo.update(changeset) do
       {:ok, user} ->
         conn
         |> Healthlocker.Auth.login(user)
         |> put_flash(:info, "User created successfully.")
-        |> redirect(to: user_path(conn, :index))
+        |> redirect(to: toolkit_path(conn, :index))
       {:error, changeset} ->
         render(conn, "signup3.html", changeset: changeset,
                                      action: "/users/#{user.id}/#{:create3}",

--- a/web/templates/coping_strategy/index.html.eex
+++ b/web/templates/coping_strategy/index.html.eex
@@ -1,4 +1,6 @@
-<h3>Coping strategies</h3>
+<h3 class="di ma3 ma4-m ma4-l mv2 mv3-m mv4-l ">Coping strategies</h3>
+<%= link "Add new", to: coping_strategy_path(@conn, :new),
+                    class: "di fr ma3 ma4-m ma4-l mv2 mv3-m mv4-l"%>
 <%= for coping_strategy <- @coping_strategies do %>
 <div class="ma3 ma4-m ma4-l mv2 mv3-m mv4-l bg-light-silver">
   <p class="pv2 ph2 ph3-m ph4-l f5 f4-ns f3-m f2-l lh-copy">

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -21,6 +21,8 @@
         <a class="pa3 f1 white-80 db hover-white" href="/">Home</a>
         <a class="pa3 f1 white-80 db hover-white" href="#">About</a>
         <%= if @current_user do %>
+          <%= link "Toolkit",  class: "pa3 f1 white-80 db hover-white",
+                               to: toolkit_path(@conn, :index) %>
           <%= link "Log out", class: "pa3 f1 white-80 db hover-white",
                               to: login_path(@conn, :delete, @current_user),
                               method: "delete" %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -27,13 +27,10 @@
                               to: login_path(@conn, :delete, @current_user),
                               method: "delete" %>
         <%= else %>
-          <div class="di pa3 mb5">
-            <%= link "Sign up", class: "f1 white-80 di hover-white",
-                to: user_path(@conn, :new) %>
-                <p class="f1 di white-80">/</p>
-            <%= link "Log in", class: "f1 white-80 di hover-white",
-                to: login_path(@conn, :index) %>
-          </div>
+          <%= link "Sign up", class: "pa3 f1 white-80 db hover-white",
+              to: user_path(@conn, :new) %>
+          <%= link "Log in", class: "pa3 f1 white-80 db hover-white",
+              to: login_path(@conn, :index) %>
         <%= end %>
         <a class="mt3 mh6 bg-light-red pv2 f1 white-80 db hover-white" href="/support">Get support</a>
       </nav>

--- a/web/templates/toolkit/index.html.eex
+++ b/web/templates/toolkit/index.html.eex
@@ -1,15 +1,18 @@
-<h3>Toolkit</h3>
-<div class="goals-container">
+<h3 class="ma3">Toolkit</h3>
+<div class="goals-strategies">
+  <a href="#">
+    <div class="goals-container bg-light-gray ma3">
+      <img src="https://cloud.githubusercontent.com/assets/1287388/23158827/69c4926e-f818-11e6-950c-8f475065da7f.png"
+      alt="trophy">
+      <h4 class="black">Goals</h4>
+    </div>
+  </a>
 
-</div>
-
-<div class="strategies-container ma3 ma4-m ma4-l mv2 mv3-m mv4-l">
-  <h3 class="di pa3 ma3 mv2">Coping Strategies</h3>
-  <%= link "Add new", to: coping_strategy_path(@conn, :new), class: "di fr"%>
-  <%= for coping_strategy <- @coping_strategies do %>
-    <p class="pv2 ph2 ph3-m ph4-l f5 f4-ns f3-m f2-l lh-copy">
-      <%= String.trim_trailing(coping_strategy.content, " #CopingStrategy")%>
-    </p>
-  <%= end %>
-  <%= link "See all coping strategies", to: coping_strategy_path(@conn, :index), class: "fr" %>
+  <a href="/coping-strategy">
+    <div class="bg-light-gray ma3">
+      <img src="https://cloud.githubusercontent.com/assets/1287388/23158828/69ce54ca-f818-11e6-94b3-b35f9f18b0e0.png"
+      alt="thumbs-up">
+      <h4 class="black">Strategies</h4>
+    </div>
+  </a>
 </div>


### PR DESCRIPTION
These are a couple of quick fixes @iteles and I noticed when going through the coping strategies flow last night. It redirects to toolkit after logging in/signing up, adds toolkit to drawer menu when logged in, and changes toolkit to images for goals and coping strategies, and separates sign up and login to different lines in the drawer menu.