### PR TITLE
Cache the build and deps directories in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: elixir
 elixir:
 - 1.3.4
+cache:
+  directories:
+    - _build
+    - deps
 notifications:
   slack:
     secure: YNQQOEi2S/m0sieziFQ7okF8BjgKBGh8RwTbU3ShuHDOCo6vlTSlaRNSgl9+QwHSlPO03k3c2DS9AKeLOCSMjOJYpjH+T6TYwh0mZ/Cc9Xa8p2i2PU76c3wTrFO+L0/rqHAbLOXu/yv9udz7RXZ7gG2vAp1Cj0wPQ2TCDa4dPtTpO6WzLuhR5ANLhipRLm8vbitM32z4TNC83jMo+Qs32k/Q11yieISM1ioBTHb0aw9p2mFUak2D+MnR4wVfDI93DOe2rCpEN6DaNZSjQfPmOIclshsXoeWhWZN065kdPitn1Drlm5YogpNZi8LFrNKoqGvZihNpjaSVBqswjiQdKld310w9IyhztOhYTBvKRcIlAs9z9pmCaj83dKXbtqc/vIpfr4CuOV6jB1ot5ib4Rjd2g0UmLXFgjRIuvoYpwr77raZjNk4dtRUi4jvGD9XucRDH6AKW80IK12q+BC5o2RTxWgdwbXm8N3/kBhX2dCirm4e0mkJmd6JtqkfL74+28fKzAyVjAgqem+/9E9NBGs0/Hv8dMsYgbwfZyEssbQ2wFNP+BHdwh3vmoZhjDyKK5t0RCUzC86wJsEuLK77EX46Dvltchh2B9A7gCtuHlh7ShA14fA5VFVlEnkeM48M0EdNfZyQs4rkIOsAHw98c2KFJZJDhb6SuIBeENQoPi7M=


### PR DESCRIPTION
Used the advice from here: https://dockyard.com/blog/2015/12/02/speeding-up-elixir-project-build-times-on-travis-ci

To reduce the build times ~2mins to ~1min 🎉 