### PR TITLE
Adds detail to README setup instructions for setup from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 #### Once everything is installed:
 * Enter `brew link autoconf automake` into your terminal
-* Open Postgresql and look for the elephant symbol in your menu bar to show that it's running
+* Open Postgresql (if you can see the elephant symbol in your menu bar you know that it's running)
 * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
 * If prompted by the following message, enter `y`:
 
-Could not find "rebar3", which is needed to build dependency :fs
+` Could not find "rebar3", which is needed to build dependency :fs
 I can install a local copy which is just used by Mix
-Shall I install rebar3? (if running non-interactively, use: "mix local.rebar --force") [Yn]
+Shall I install rebar3? (if running non-interactively, use: "mix local.rebar --force") [Yn] `
 * Install Node.js dependencies with `npm install`
 * Start Phoenix endpoint with `mix phoenix.server`
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # Healthlocker
 
-To start your Phoenix app:
+## Getting started
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
-  * Install Node.js dependencies with `npm install`
-  * Start Phoenix endpoint with `mix phoenix.server`
+#### Install the following:
+* [Elixir](https://github.com/dwyl/learn-elixir#how)
+* [Postgresql](https://github.com/dwyl/learn-postgresql)
+* [Node.js](https://nodejs.org/en/)
+
+#### Once everything is installed:
+* Enter `brew link autoconf automake` into your terminal
+* Open Postgresql and look for the elephant symbol in your menu bar to show that it's running
+* Create and migrate your database with `mix ecto.create && mix ecto.migrate`
+* If prompted by the following message, enter `y`:
+
+Could not find "rebar3", which is needed to build dependency :fs
+I can install a local copy which is just used by Mix
+Shall I install rebar3? (if running non-interactively, use: "mix local.rebar --force") [Yn]
+* Install Node.js dependencies with `npm install`
+* Start Phoenix endpoint with `mix phoenix.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
+Ready to run in production? Please [check the deployment guides](http://www.phoenixframework.org/docs/deployment).
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #### Install the following:
 * [Elixir](https://github.com/dwyl/learn-elixir#how)
-* [Postgresql](https://github.com/dwyl/learn-postgresql)
+* [Postgresql](https://github.com/dwyl/learn-postgresql) (and ensure you create a user)
 * [Node.js](https://nodejs.org/en/)
 
 #### Once everything is installed:


### PR DESCRIPTION
- Separates README instructions into installation list (for non-technical new users) and command line instructions (for everyone to follow) once initial installation is complete to break down size of instructions.
- Adds line to prevent brew error: `brew link autoconf automake`
- Specifies that postgresql must be installed/ open with a user created to resolve issues #147 #80 
- Indicates readers should enter `y` when prompted by this message:
` Could not find "rebar3", which is needed to build dependency :fs
I can install a local copy which is just used by Mix
Shall I install rebar3? (if running non-interactively, use: "mix local.rebar --force") [Yn] `

Fixes #147  #80 