### PR TITLE
Connecting info

### DIFF
--- a/test/controllers/account_controller_test.exs
+++ b/test/controllers/account_controller_test.exs
@@ -134,6 +134,11 @@ defmodule Healthlocker.AccountControllerTest do
       conn = put conn, account_path(conn, :update_password), user: @wrong_confirmation
       assert html_response(conn, 200) =~ "Current password"
     end
+
+    test "renders connecting slam info", %{conn: conn} do
+      conn = get conn, account_path(conn, :slam_help)
+      assert html_response(conn, 200) =~ "To connect you will need to enter"
+    end
   end
 
   describe "connection is halted if there is no current_user" do
@@ -163,6 +168,12 @@ defmodule Healthlocker.AccountControllerTest do
 
     test "update user data_access", %{conn: conn} do
       conn = put conn, account_path(conn, :update_consent), user: %{data_access: true}
+      assert html_response(conn, 302)
+      assert conn.halted
+    end
+
+    test "slam_help is redirect and halted", %{conn: conn} do
+      conn = get conn, account_path(conn, :slam_help)
       assert html_response(conn, 302)
       assert conn.halted
     end

--- a/web/controllers/account_controller.ex
+++ b/web/controllers/account_controller.ex
@@ -123,6 +123,12 @@ defmodule Healthlocker.AccountController do
     render conn, "slam.html", user: user
   end
 
+  def slam_help(conn, _params) do
+    user_id = conn.assigns.current_user.id
+    user = Repo.get!(User, user_id)
+    render conn, "slam_help.html", user: user
+  end
+
   defp authenticate(conn, _opts) do
     if conn.assigns.current_user do
       conn

--- a/web/router.ex
+++ b/web/router.ex
@@ -43,6 +43,7 @@ defmodule Healthlocker.Router do
     get "/account/password/edit", AccountController, :edit_password
     put "/account/password/update", AccountController, :update_password
     get "/account/slam", AccountController, :slam
+    get "/account/slam-help", AccountController, :slam_help
 
   end
 

--- a/web/templates/account/index.html.eex
+++ b/web/templates/account/index.html.eex
@@ -13,8 +13,10 @@
     </div>
 
     <%= if @user.slam_user do %>
-      <%= link "Connect with my SLaM care team and health record ?", to: account_path(@conn, :slam) %>
+      <%= link "Connect with my SLaM care team and health record", to: account_path(@conn, :slam) %>
+      <%= link "(?)", to: account_path(@conn, :slam_help) %>
     <% end %>
+
 
     <div class="form-group mt4">
       <%= label f, "Name (optional)", class: "control-label" %>

--- a/web/templates/account/slam_help.html.eex
+++ b/web/templates/account/slam_help.html.eex
@@ -1,0 +1,14 @@
+<div class="ma3 ma4-m ma4-l mv2 mv3-m mv4-l f3-m f2-l">
+  <p>To connect you will need to enter your NHS number, First name, Last name
+  and Date of Birth, these details will be matched against your SLaM record -
+  they must match perfectly.</p>
+
+  <p>Once your account has been connected you will
+  be able to see the contact details of the SLaM staff you see, view your
+  current care plan, interact with your goals and coping strategies from your
+  care plan, receive recommendations and resources from your care team and
+  more. What you share with your care team, is up to you.</p>
+
+
+  <%= link "Close", to: account_path(@conn, :index)%>
+</div>


### PR DESCRIPTION
This displays information to the user for how and why to connect with SLaM #136. 

The information is displayed on a separate page from the profile and the user can go back by clicking close at the bottom.