### PR TITLE
Account security tab (2/3)

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -11,8 +11,9 @@ button {
 }
 
 /*elements*/
-a:hover {
-  color: #25bdc3;
+
+a {
+  outline: none!important;
 }
 
 input {
@@ -113,4 +114,9 @@ select:focus {
 
 .hl-bg-error {
   background-color: #25BDC3;
+}
+
+.b--hl-aqua {
+  border-width: medium;
+  border-color: #25bdc3;
 }

--- a/web/templates/account/index.html.eex
+++ b/web/templates/account/index.html.eex
@@ -1,14 +1,14 @@
 <div class="ma3 ma4-m ma4-l mv2 mv3-m mv4-l">
   <%= render "menu.html", conn: @conn %>
 
-  <div class="mt6">
+  <div class="mt5">
 
     <%= if !@slam_user do %>
       <%= render "profile.html", assigns %>
     <% end %>
   </div>
 
-  <div class="mt6">
+  <div class="mt5">
     <%= if @slam_user do %>
       <%= render "slam_connected.html", assigns %>
     <% end %>

--- a/web/templates/account/menu.html.eex
+++ b/web/templates/account/menu.html.eex
@@ -1,6 +1,21 @@
 <h3 class="tc">Account</h3>
 <div class="w-100">
-  <%= link "Profile", to: account_path(@conn, :index), class: "w-33 ba dib fl black tc pv1 bg-silver" %>
-  <%= link "Security", to: account_path(@conn, :security), class: "w-33 ba dib fl black tc pv1 bg-silver" %>
-  <%= link "Consent", to: account_path(@conn, :consent), class: "w-33 ba dib fl black tc pv1 bg-silver" %>
+  <%= cond do %>
+   <%= @conn.request_path == "/account" -> %>
+     <%= link "Profile", to: account_path(@conn, :index), class: "link w-33 bb dib fl black tc pv1 b--hl-aqua" %>
+     <%= link "Security", to: account_path(@conn, :security), class: "link w-33 dib fl black tc pv1 bg-white" %>
+     <%= link "Consent", to: account_path(@conn, :consent), class: "link w-33 dib fl black tc pv1 bg-white" %>
+   <%= @conn.request_path == "/account/security" -> %>
+     <%= link "Profile", to: account_path(@conn, :index), class: "link w-33 dib fl black tc pv1 bg-white" %>
+     <%= link "Security", to: account_path(@conn, :security), class: "link w-33 bb dib fl black tc pv1 b--hl-aqua" %>
+     <%= link "Consent", to: account_path(@conn, :consent), class: "link w-33 dib fl black tc pv1 bg-white" %>
+   <%= @conn.request_path == "/account/consent" -> %>
+     <%= link "Profile", to: account_path(@conn, :index), class: "link w-33 dib fl black tc pv1 bg-white" %>
+     <%= link "Security", to: account_path(@conn, :security), class: "link w-33 dib fl black tc pv1 bg-white" %>
+     <%= link "Consent", to: account_path(@conn, :consent), class: "link w-33 bb dib fl black tc pv1 b--hl-aqua" %>
+   <%= true -> %>
+     <%= link "Profile", to: account_path(@conn, :index), class: "link w-33 bb b--black-30 dib fl black tc pv1 bg-white" %>
+     <%= link "Security", to: account_path(@conn, :security), class: "link w-33 bb b--black-30 dib fl black tc pv1 bg-white" %>
+     <%= link "Consent", to: account_path(@conn, :consent), class: "link w-33 bb b--black-30 dib fl black tc pv1 bg-white" %>
+ <% end %>
 </div>

--- a/web/templates/account/profile.html.eex
+++ b/web/templates/account/profile.html.eex
@@ -1,10 +1,10 @@
 <%= form_for @changeset, @action, fn f -> %>
   <input name="_method" type="hidden" value="put" />
 
-  <div class="form-group">
+  <div class="form-group pt3-m">
+    <%= checkbox f, :slam_user, class: "checkbox " %>
     <%= label f, "I am a South London and Maudsley service user.",
         class: "control-label" %>
-    <%= checkbox f, :slam_user, class: "form-control" %>
     <%= error_tag f, :slam_user %>
   </div>
 
@@ -13,23 +13,23 @@
     <%= link "(?)", to: account_path(@conn, :slam_help) %>
   <% end %>
 
-  <div class="form-group mt4">
-    <%= label f, "Name (optional)", class: "control-label" %>
-    <%= text_input f, :name, class: "form-control" %>
+  <div class="form-group mt3">
+    <%= label f, "Name (optional)", class: "f5 b db mb2" %>
+    <%= text_input f, :name, class: "pa3 input-reset bn hl-bg-grey w-100" %>
     <%= error_tag f, :name %>
   </div>
 
-  <div class="form-group">
-    <%= label f, :email, class: "control-label" %>
-    <%= text_input f, :email, class: "form-control" %>
+  <div class="form-group mt4">
+    <%= label f, :email, class: "f5 b db mb2" %>
+    <%= text_input f, :email, class: "pa3 input-reset bn hl-bg-grey w-100" %>
     <%= error_tag f, :email%>
   </div>
 
-  <div class="form-group">
-    <%= label f, "Phone number (optional)", class: "control-label" %>
-    <%= text_input f, :phone_number, class: "form-control" %>
+  <div class="form-group mt4">
+    <%= label f, "Phone number (optional)", class: "f5 b db mb2" %>
+    <%= text_input f, :phone_number, class: "pa3 input-reset bn hl-bg-grey w-100" %>
     <%= error_tag f, :email%>
   </div>
 
-  <%= submit "Update", class: "fr bg-near-white b--black-10 black-50 b pv1" %>
+  <%= submit "Update", class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer fr w-40" %>
 <% end %>

--- a/web/templates/account/profile.html.eex
+++ b/web/templates/account/profile.html.eex
@@ -1,7 +1,7 @@
 <%= form_for @changeset, @action, fn f -> %>
   <input name="_method" type="hidden" value="put" />
 
-  <div class="form-group pt3-m">
+  <div class="form-group pv3">
     <%= checkbox f, :slam_user, class: "checkbox " %>
     <%= label f, "I am a South London and Maudsley service user.",
         class: "control-label" %>

--- a/web/templates/account/security.html.eex
+++ b/web/templates/account/security.html.eex
@@ -1,6 +1,7 @@
 <div class="ma3 ma4-m ma4-l mv2 mv3-m mv4-l">
   <%= render "menu.html", conn: @conn %>
-
-  <%= link "Update password", to: account_path(@conn, :edit_password), class: "db mt6" %>
-  <%= link "Update security question", to: account_path(@conn, :edit_security), class: "db mt3"%>
+    <section class="w-100 h-100 tc">
+      <%= link "Update password", to: account_path(@conn, :edit_password), class: "mt6 f5 tc link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-80 " %>
+      <%= link "Update security question", to: account_path(@conn, :edit_security), class: "mt4 f5 tc link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-80"%>
+    </section>
 </div>


### PR DESCRIPTION
Styles links on security tab to look like buttons, for clearer 'call to action'.

Fixes #223
