### PR TITLE
Set up goals for schema changes

### DIFF
--- a/priv/repo/migrations/20170309161933_create_goals.exs
+++ b/priv/repo/migrations/20170309161933_create_goals.exs
@@ -1,0 +1,13 @@
+defmodule Healthlocker.Repo.Migrations.CreateGoals do
+  use Ecto.Migration
+
+  def change do
+    create table(:goals) do
+      add :content, :string, null: false
+      add :completed, :boolean
+      add :notes, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20170309161933_create_goals.exs
+++ b/priv/repo/migrations/20170309161933_create_goals.exs
@@ -6,6 +6,7 @@ defmodule Healthlocker.Repo.Migrations.CreateGoals do
       add :content, :string, null: false
       add :completed, :boolean
       add :notes, :string
+      add :user_id, references(:users)
 
       timestamps()
     end

--- a/test/controllers/goal_controller_test.exs
+++ b/test/controllers/goal_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Healthlocker.GoalControllerTest do
   use Healthlocker.ConnCase
 
-  alias Healthlocker.Post
+  alias Healthlocker.Goal
   alias Healthlocker.User
 
   @valid_attrs %{content: "some content"}
@@ -25,13 +25,13 @@ defmodule Healthlocker.GoalControllerTest do
     end
 
     test "renders index.html on /goals", %{conn: conn} do
-      Repo.insert %Post{content: "some content #Goal", user_id: 123456}
+      Repo.insert %Goal{content: "some content #Goal", user_id: 123456}
       conn = get conn, goal_path(conn, :index)
       assert html_response(conn, 200) =~ "Goals"
     end
 
     test "shows chosen goal", %{conn: conn} do
-      goal = Repo.insert! %Post{content: "some content",  user_id: 123456}
+      goal = Repo.insert! %Goal{content: "some content",  user_id: 123456}
       conn = get conn, goal_path(conn, :show, goal)
       assert html_response(conn, 200) =~ "Toolkit"
     end
@@ -48,36 +48,36 @@ defmodule Healthlocker.GoalControllerTest do
     end
 
     test "creates goal and redirects when data is valid", %{conn: conn} do
-      conn = post conn, goal_path(conn, :create), post: @valid_attrs
+      conn = post conn, goal_path(conn, :create), goal: @valid_attrs
       assert redirected_to(conn) == goal_path(conn, :index)
-      assert Repo.get_by(Post, content: "some content #Goal")
+      assert Repo.get_by(Goal, content: "some content #Goal")
     end
 
     test "does not create goal and renders errors when data is invalid", %{conn: conn} do
-      conn = post conn, goal_path(conn, :create), post: @invalid_attrs
+      conn = post conn, goal_path(conn, :create), goal: @invalid_attrs
       assert html_response(conn, 200) =~ "Add new"
     end
 
     test "renders form for editing goal", %{conn: conn} do
-      goal = Repo.insert %Post{content: "some content #Goal", user_id: 123456}
+      goal = Repo.insert %Goal{content: "some content #Goal", user_id: 123456}
       conn = get conn, goal_path(conn, :edit, elem(goal, 1))
       assert html_response(conn, 200) =~ "Edit goal"
     end
 
     test "updates goal with valid data", %{conn: conn} do
-      goal = Repo.insert! %Post{content: "some stuff"}
-      conn = put conn, goal_path(conn, :update, goal), post: @valid_attrs
+      goal = Repo.insert! %Goal{content: "some stuff"}
+      conn = put conn, goal_path(conn, :update, goal), goal: @valid_attrs
       assert redirected_to(conn) == goal_path(conn, :show, goal)
     end
 
     test "does not update goal when data is invalid", %{conn: conn} do
-      goal = Repo.insert! %Post{content: "some stuff"}
-      conn = put conn, goal_path(conn, :update, goal), post: @invalid_attrs
+      goal = Repo.insert! %Goal{content: "some stuff"}
+      conn = put conn, goal_path(conn, :update, goal), goal: @invalid_attrs
       assert html_response(conn, 200) =~ "Edit goal"
     end
 
     test "delete chosen goal", %{conn: conn} do
-      goal = Repo.insert! %Post{content: "some content", user_id: 123456}
+      goal = Repo.insert! %Goal{content: "some content", user_id: 123456}
       conn = delete conn, goal_path(conn, :delete, goal)
       assert redirected_to(conn) == goal_path(conn, :index)
     end
@@ -97,14 +97,14 @@ defmodule Healthlocker.GoalControllerTest do
     end
 
     test "create", %{conn: conn} do
-      conn = post conn, goal_path(conn, :create), post: @valid_attrs
+      conn = post conn, goal_path(conn, :create), goal: @valid_attrs
       assert html_response(conn, 302)
       assert conn.halted
     end
 
     test "update", %{conn: conn} do
-      goal = Repo.insert! %Post{content: "some stuff"}
-      conn = put conn, goal_path(conn, :update, goal), post: @valid_attrs
+      goal = Repo.insert! %Goal{content: "some stuff"}
+      conn = put conn, goal_path(conn, :update, goal), goal: @valid_attrs
       assert html_response(conn, 302)
       assert conn.halted
     end
@@ -119,7 +119,7 @@ defmodule Healthlocker.GoalControllerTest do
         password_hash: Comeonin.Bcrypt.hashpwsalt("password")
         } |> Repo.insert
 
-      {:ok, goal: Repo.insert! %Post{content: "some content", user_id: 123456}}
+      {:ok, goal: Repo.insert! %Goal{content: "some content", user_id: 123456}}
     end
 
     test "show", %{conn: conn, goal: goal} do
@@ -129,7 +129,7 @@ defmodule Healthlocker.GoalControllerTest do
     end
 
     test "edit", %{conn: conn} do
-      goal = Repo.insert %Post{content: "some content #Goal", user_id: 123456}
+      goal = Repo.insert %Goal{content: "some content #Goal", user_id: 123456}
       conn = get conn, goal_path(conn, :edit, elem(goal, 1))
       assert html_response(conn, 302)
       assert conn.halted

--- a/test/models/goal_test.exs
+++ b/test/models/goal_test.exs
@@ -1,0 +1,17 @@
+defmodule Healthlocker.GoalTest do
+  use Healthlocker.ModelCase, async: true
+  alias Healthlocker.Goal
+
+  @valid_attrs %{content: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Goal.changeset(%Goal{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Goal.changeset(%Goal{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/controllers/goal_controller.ex
+++ b/web/controllers/goal_controller.ex
@@ -3,12 +3,12 @@ defmodule Healthlocker.GoalController do
 
   plug :authenticate
 
-  alias Healthlocker.Post
+  alias Healthlocker.Goal
 
   def index(conn, _params) do
     user_id = conn.assigns.current_user.id
-    goals = Post
-           |> Post.get_goals(user_id)
+    goals = Goal
+           |> Goal.get_goals(user_id)
            |> Repo.all
     if Kernel.length(goals) == 0 do
       conn
@@ -19,26 +19,26 @@ defmodule Healthlocker.GoalController do
   end
 
   def new(conn, _params) do
-    changeset =  Post.changeset(%Post{})
+    changeset =  Goal.changeset(%Goal{})
     render(conn, "new.html", changeset: changeset)
   end
 
   def show(conn, %{"id" => id}) do
     user_id = conn.assigns.current_user.id
-    goal = Post
-          |> Post.get_goal_by_user(id, user_id)
+    goal = Goal
+          |> Goal.get_goal_by_user(id, user_id)
           |> Repo.one!
     render conn, "show.html", goal: goal
   end
 
-  def create(conn, %{"post" => goal_params}) do
+  def create(conn, %{"goal" => goal_params}) do
     content = get_content(goal_params)
     user_id = get_session(conn, :user_id)
-    changeset = Post.changeset(%Post{}, content)
-    changeset = Ecto.Changeset.put_change(changeset, :user_id, user_id)
+    changeset = Goal.changeset(%Goal{}, content)
+              |> Ecto.Changeset.put_change(:user_id, user_id)
 
     case Repo.insert(changeset) do
-      {:ok, _post} ->
+      {:ok, _goal} ->
         conn
         |> put_flash(:info, "Goal added!")
         |> redirect(to: goal_path(conn, :index))
@@ -49,18 +49,18 @@ defmodule Healthlocker.GoalController do
 
   def edit(conn, %{"id" => id}) do
     user_id = conn.assigns.current_user.id
-    goal = Post
-          |> Post.get_goal_by_user(id, user_id)
+    goal = Goal
+          |> Goal.get_goal_by_user(id, user_id)
           |> Repo.one
           |> Map.update!(:content, &(String.trim_trailing(&1, " #Goal")))
-    changeset = Post.changeset(goal)
+    changeset = Goal.changeset(goal)
     render(conn, "edit.html", goal: goal, changeset: changeset)
   end
 
-  def update(conn, %{"id" => id, "post" => goal_params}) do
-    goal = Repo.get!(Post, id)
+  def update(conn, %{"id" => id, "goal" => goal_params}) do
+    goal = Repo.get!(Goal, id)
     content = get_content(goal_params)
-    changeset = Post.changeset(goal, content)
+    changeset = Goal.changeset(goal, content)
 
     case Repo.update(changeset) do
       {:ok, goal} ->
@@ -74,8 +74,8 @@ defmodule Healthlocker.GoalController do
 
   def delete(conn, %{"id" => id}) do
     user_id = conn.assigns.current_user.id
-    goal = Post
-          |> Post.get_goal_by_user(id, user_id)
+    goal = Goal
+          |> Goal.get_goal_by_user(id, user_id)
           |> Repo.one
 
     Repo.delete!(goal)

--- a/web/models/goal.ex
+++ b/web/models/goal.ex
@@ -1,0 +1,18 @@
+defmodule Healthlocker.Goal do
+  use Healthlocker.Web, :model
+
+  schema "goals" do
+    field :content, :string
+    field :completed, :boolean
+    field :notes, :string
+
+    timestamps()
+  end
+
+  def changeset(struct, params \\ :invalid) do
+    struct
+    | cast(params, [:content])
+    |> validate_required(:content)
+  end
+
+end

--- a/web/models/goal.ex
+++ b/web/models/goal.ex
@@ -5,14 +5,24 @@ defmodule Healthlocker.Goal do
     field :content, :string
     field :completed, :boolean
     field :notes, :string
+    belongs_to :user, Healthlocker.User
 
     timestamps()
   end
 
   def changeset(struct, params \\ :invalid) do
     struct
-    | cast(params, [:content])
+    |> cast(params, [:content])
     |> validate_required(:content)
   end
 
+  def get_goals(query, user_id) do
+    from p in query,
+    where: like(p.content, "%#Goal") and p.user_id == ^user_id
+  end
+
+  def get_goal_by_user(query, id, user_id) do
+    from p in query,
+    where: p.id == ^id and p.user_id == ^user_id
+  end
 end

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -56,14 +56,4 @@ defmodule Healthlocker.Post do
     from p in query,
     where: p.id == ^id and p.user_id == ^user_id
   end
-
-  def get_goals(query, user_id) do
-    from p in query,
-    where: like(p.content, "%#Goal") and p.user_id == ^user_id
-  end
-
-  def get_goal_by_user(query, id, user_id) do
-    from p in query,
-    where: p.id == ^id and p.user_id == ^user_id
-  end
 end


### PR DESCRIPTION
Start on #211. The goals are now added to and get from the goals table instead of posts table, so more fields can be added which are unique to goals. 