### PR TITLE
Icon size fix

### DIFF
--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -29,7 +29,7 @@
         <header id="header" class="hl-bg-aqua w-100 ph3 pv3 pv4-ns ph4-m ph5-l tc">
           <nav class="f4 fw3 tracked">
             <i id="open-nav" class="fa fa-bars dim white dib fl" aria-hidden="true"></i>
-            <a href="/"><%= img_tag("/images/logo.png", class: "w-70") %></a>
+            <a href="/"><%= img_tag("/images/logo.png", class: "w-60 w-50-m mw5") %></a>
           </nav>
         </header>
 

--- a/web/templates/toolkit/index.html.eex
+++ b/web/templates/toolkit/index.html.eex
@@ -1,17 +1,17 @@
-<div class="ma3 ma4-m ma4-l mv2 mv3-m mv4-l">
+<div class="ma3 ma4-m ma4-l">
   <h3 class="tc">Toolkit</h3>
-  <div class="goals-strategies">
-      <div class="tc goals-container ma3">
+  <div class="goals-strategies w-100 mw6 center">
+      <div class="tc goals-container w-40 fl">
         <a href="/goal">
-        <%= img_tag("/images/HL_icons_Goals.svg", class: "w-60") %>
-        <span class="mt3 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-40">Goals</span>
+        <%= img_tag("/images/HL_icons_Goals.svg", class: "w-100") %>
+        <span class="mt3 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-75">Goals</span>
         </a>
       </div>
 
-      <div class="tc ma3 pt2">
+      <div class="tc w-40 fr">
         <a href="/coping-strategy">
-        <%= img_tag("/images/HL_icons_Strategies.svg", class: "w-60") %>
-        <span class="mt3 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-40">Strategies</span>
+        <%= img_tag("/images/HL_icons_Strategies.svg", class: "w-100") %>
+        <span class="mt3 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer w-75">Strategies</span>
         </a>
       </div>
   </div>


### PR DESCRIPTION
Addresses #321 

Fixes the size of the icons in toolkit - both were very large and the user needed to scroll down no matter what the screen size to click each icon. The icons are now side by side. 

The header logo was also resized on various devices as part of fixing this issue. There was not much space on the page, even with resizing the icons to a more reasonable size, and adding any more content would likely result in the user still scrolling due to the header taking up so much space (on large screens).