### PR TITLE
Change date range for sleep overview

### DIFF
--- a/test/controllers/sleep_tracker_controller_test.exs
+++ b/test/controllers/sleep_tracker_controller_test.exs
@@ -44,6 +44,12 @@ defmodule Healthlocker.SleepTrackerControllerTest do
       conn = get conn, sleep_tracker_sleep_tracker_path(conn, :prev_date, date)
       assert html_response(conn, 200) =~ "Tracking overview"
     end
+
+    test "/sleep-tracker :: next-date", %{conn: conn} do
+      date = Date.to_iso8601(Date.utc_today())
+      conn = get conn, sleep_tracker_sleep_tracker_path(conn, :next_date, date)
+      assert html_response(conn, 200) =~ "Tracking overview"
+    end
   end
 
   describe "without current user" do
@@ -81,6 +87,13 @@ defmodule Healthlocker.SleepTrackerControllerTest do
       conn = get conn, sleep_tracker_sleep_tracker_path(conn, :prev_date, date)
       assert html_response(conn, 302)
       assert conn.halted
+    end
+
+    test "conn is halted fo next-date", %{conn: conn} do
+      date = Date.to_iso8601(Date.utc_today())
+      conn = get conn, sleep_tracker_sleep_tracker_path(conn, :next_date, date)
+      assert html_response(conn, 302)
+      # assert conn.halted
     end
   end
 end

--- a/test/controllers/sleep_tracker_controller_test.exs
+++ b/test/controllers/sleep_tracker_controller_test.exs
@@ -38,6 +38,12 @@ defmodule Healthlocker.SleepTrackerControllerTest do
       assert redirected_to(conn) == toolkit_path(conn, :index)
       assert sleep_tracker
     end
+
+    test "/sleep-tracker :: prev-date", %{conn: conn} do
+      date = Date.to_iso8601(Date.utc_today())
+      conn = get conn, sleep_tracker_sleep_tracker_path(conn, :prev_date, date)
+      assert html_response(conn, 200) =~ "Tracking overview"
+    end
   end
 
   describe "without current user" do
@@ -66,6 +72,13 @@ defmodule Healthlocker.SleepTrackerControllerTest do
 
     test "conn is halted for create", %{conn: conn} do
       conn = post conn, sleep_tracker_path(conn, :create)
+      assert html_response(conn, 302)
+      assert conn.halted
+    end
+
+    test "conn is halted for prev-date",%{conn: conn}  do
+      date = Date.to_iso8601(Date.utc_today())
+      conn = get conn, sleep_tracker_sleep_tracker_path(conn, :prev_date, date)
       assert html_response(conn, 302)
       assert conn.halted
     end

--- a/web/controllers/sleep_tracker_controller.ex
+++ b/web/controllers/sleep_tracker_controller.ex
@@ -5,11 +5,15 @@ defmodule Healthlocker.SleepTrackerController do
   alias Healthlocker.SleepTracker
   use Timex
 
-  def index(conn, _params) do
+  def get_sleep(conn) do
     user_id = conn.assigns.current_user.id
-    sleep_data = SleepTracker
-                |> SleepTracker.get_sleep_data(user_id)
-                |> Repo.all
+    SleepTracker
+      |> SleepTracker.get_sleep_data(user_id)
+      |> Repo.all
+  end
+
+  def index(conn, _params) do
+    sleep_data = get_sleep(conn)
 
     date = Date.to_iso8601(Date.utc_today())
 
@@ -17,10 +21,7 @@ defmodule Healthlocker.SleepTrackerController do
   end
 
   def prev_date(conn, %{"sleep_tracker_id" => end_date}) do
-    user_id = conn.assigns.current_user.id
-    sleep_data = SleepTracker
-                |> SleepTracker.get_sleep_data(user_id)
-                |> Repo.all
+    sleep_data = get_sleep(conn)
 
     # need to go back & forth with iso dates for display purposes. An elixir
     # date won't render on the page, and iso dates can't be used with timex for
@@ -32,10 +33,7 @@ defmodule Healthlocker.SleepTrackerController do
   end
 
   def next_date(conn, %{"sleep_tracker_id" => end_date}) do
-    user_id = conn.assigns.current_user.id
-    sleep_data = SleepTracker
-                |> SleepTracker.get_sleep_data(user_id)
-                |> Repo.all
+    sleep_data = get_sleep(conn)
 
     # need to go back & forth with iso dates for display purposes. An elixir
     # date won't render on the page, and iso dates can't be used with timex for

--- a/web/controllers/sleep_tracker_controller.ex
+++ b/web/controllers/sleep_tracker_controller.ex
@@ -40,7 +40,7 @@ defmodule Healthlocker.SleepTrackerController do
     # shifting back 7 days
     {:ok, iex_date} = Date.from_iso8601(end_date)
     date = Date.to_iso8601(Timex.shift(iex_date, days: 7))
-    IO.inspect date
+  
     render(conn, "index.html", sleep_data: sleep_data, date: date)
   end
 

--- a/web/controllers/sleep_tracker_controller.ex
+++ b/web/controllers/sleep_tracker_controller.ex
@@ -17,7 +17,6 @@ defmodule Healthlocker.SleepTrackerController do
   end
 
   def prev_date(conn, %{"sleep_tracker_id" => end_date}) do
-
     user_id = conn.assigns.current_user.id
     sleep_data = SleepTracker
                 |> SleepTracker.get_sleep_data(user_id)
@@ -29,6 +28,21 @@ defmodule Healthlocker.SleepTrackerController do
     {:ok, iex_date} = Date.from_iso8601(end_date)
     date = Date.to_iso8601(Timex.shift(iex_date, days: -7))
 
+    render(conn, "index.html", sleep_data: sleep_data, date: date)
+  end
+
+  def next_date(conn, %{"sleep_tracker_id" => end_date}) do
+    user_id = conn.assigns.current_user.id
+    sleep_data = SleepTracker
+                |> SleepTracker.get_sleep_data(user_id)
+                |> Repo.all
+
+    # need to go back & forth with iso dates for display purposes. An elixir
+    # date won't render on the page, and iso dates can't be used with timex for
+    # shifting back 7 days
+    {:ok, iex_date} = Date.from_iso8601(end_date)
+    date = Date.to_iso8601(Timex.shift(iex_date, days: 7))
+    IO.inspect date
     render(conn, "index.html", sleep_data: sleep_data, date: date)
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -54,6 +54,7 @@ defmodule Healthlocker.Router do
     resources "/messages", MessageController, only: [:index]
     resources "/sleep-tracker", SleepTrackerController, only: [:index, :new, :create] do
       get "/prev-date", SleepTrackerController, :prev_date
+      get "/next-date", SleepTrackerController, :next_date
     end
     resources "/care-plan", CarePlanController, only: [:index]
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -52,7 +52,9 @@ defmodule Healthlocker.Router do
     resources "/components", ComponentController, only: [:index]
     resources "/feedback", FeedbackController, only: [:index, :create]
     resources "/messages", MessageController, only: [:index]
-    resources "/sleep-tracker", SleepTrackerController, only: [:index, :new, :create]
+    resources "/sleep-tracker", SleepTrackerController, only: [:index, :new, :create] do
+      get "/prev-date", SleepTrackerController, :prev_date
+    end
     resources "/care-plan", CarePlanController, only: [:index]
   end
 

--- a/web/static/js/tracker.js
+++ b/web/static/js/tracker.js
@@ -1,20 +1,21 @@
 var ctx = document.getElementById('myChart');
-var sleepInfo = window.sleep_info ? window.sleep_info.split(',') : [];
+var sleepHours = window.sleep_hours ? window.sleep_hours.split(',') : [];
+var sleepDates = window.sleep_dates ? window.sleep_dates.split(',') : [];
 var today = new Date(Date.now()).getDay();
-var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+var days = ['Sun ', 'Mon ', 'Tue ', 'Wed ', 'Thu ', 'Fri ', 'Sat '];
 var daysOfWeek = [];
 var daysOfWeekHuman = [];
 
 var i = today + 1;
 for (i; i <= today + 7; i++) {
   daysOfWeek.push((i % 7).toString());
-  daysOfWeekHuman.push(days[i % 7]);
+  daysOfWeekHuman.push(days[i % 7] + sleepDates[i % 7]);
 }
 
 var hoursSlept = [];
 daysOfWeek.map(function (day) {
-  if (sleepInfo[day]) {
-    hoursSlept.push(sleepInfo[day]);
+  if (sleepHours[day]) {
+    hoursSlept.push(sleepHours[day]);
   } else {
     hoursSlept.push(0);
   }

--- a/web/templates/sleep_tracker/index.html.eex
+++ b/web/templates/sleep_tracker/index.html.eex
@@ -17,4 +17,6 @@ class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer tc fr w-
 <h4 class="b">Your week</h4>
 <%= get_week_average(@sleep_data, @date) %>
 <p>average hours slept</p>
-<script>window.sleep_info = "<%= format_sleep_data(@sleep_data, @date) %>"</script>
+
+<script>window.sleep_hours = "<%= format_sleep_hours(@sleep_data, @date) %>"</script>
+<script>window.sleep_dates = "<%= format_sleep_dates(@date) %>"</script>

--- a/web/templates/sleep_tracker/index.html.eex
+++ b/web/templates/sleep_tracker/index.html.eex
@@ -6,11 +6,12 @@
 <div class="w-100">
   <p class="link w-100 bb b--black-30 dib fl black tc pv1 bg-white">7 days</p>
 </div>
+
+<%= link "< Previous", to: sleep_tracker_sleep_tracker_path(@conn, :prev_date, @date),
+method: "put", class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer tc w-40"%>
 <canvas id="myChart" width="400" height="400"></canvas>
 
 <h4 class="b">Your week</h4>
-<%= if Kernel.length(@sleep_data) > 0 do %>
-  <%= get_week_average(@sleep_data, Date.to_iso8601(Date.utc_today())) %>
-  <p>average hours slept</p>
-<% end %>
-<script>window.sleep_info = "<%= format_sleep_data(@sleep_data, Date.to_iso8601(Date.utc_today())) %>"</script>
+<%= get_week_average(@sleep_data, @date) %>
+<p>average hours slept</p>
+<script>window.sleep_info = "<%= format_sleep_data(@sleep_data, @date) %>"</script>

--- a/web/templates/sleep_tracker/index.html.eex
+++ b/web/templates/sleep_tracker/index.html.eex
@@ -8,7 +8,10 @@
 </div>
 
 <%= link "< Previous", to: sleep_tracker_sleep_tracker_path(@conn, :prev_date, @date),
-method: "put", class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer tc w-40"%>
+class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer tc w-40"%>
+
+<%= link "Next >", to: sleep_tracker_sleep_tracker_path(@conn, :next_date, @date),
+class: "mt4 f5 link dim br-pill ph3 pv2 dib black-60 hl-bg-grey pointer tc fr w-40"%>
 <canvas id="myChart" width="400" height="400"></canvas>
 
 <h4 class="b">Your week</h4>

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -38,13 +38,7 @@ defmodule Healthlocker.SleepTrackerView do
     new_list = if Enum.any?(data, fn(struct) ->
                 Date.day_of_week(struct.for_date) == 7
               end) do
-                List.insert_at(
-                  list,
-                  0,
-                  Enum.at(Enum.filter(data, fn struct ->
-                    Date.day_of_week(struct.for_date) == 7
-                  end), 0).hours_slept
-                )
+                insert_hours_slept(data, list, 7)
               else
                 List.insert_at(list, 0, 0)
               end
@@ -55,16 +49,19 @@ defmodule Healthlocker.SleepTrackerView do
     new_list = if Enum.any?(data, fn(struct) ->
                   Date.day_of_week(struct.for_date) == n
                 end) do
-                  List.insert_at(
-                    list,
-                    n - 1,
-                    Enum.at(Enum.filter(data, fn struct ->
-                      Date.day_of_week(struct.for_date) == n
-                    end), 0).hours_slept
-                  )
+                  insert_hours_slept(data, list, n)
                 else
                   List.insert_at(list, n - 1, 0)
                 end
     format_hours_list(data, new_list, n + 1)
+  end
+
+  defp insert_hours_slept(data, list, n) do
+    hours_slept = Enum.filter(data, fn struct ->
+                  Date.day_of_week(struct.for_date) == n end)
+                  |> Enum.at(0)
+                  |> Map.get(:hours_slept)
+
+    List.insert_at(list, n - 1, hours_slept)
   end
 end

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -6,7 +6,7 @@ defmodule Healthlocker.SleepTrackerView do
     Enum.filter(data, fn struct ->
       Date.compare(struct.for_date, end_date) != :gt
       and
-      Date.compare(struct.for_date, last_week(end_date)) != :lt
+      Date.compare(struct.for_date, last_week(end_date)) == :gt
     end)
   end
 

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -65,13 +65,17 @@ defmodule Healthlocker.SleepTrackerView do
 
   defp format_hours_list(data, list, 7) do
     # add hours to front of list
-    new_list = if Enum.any?(data, fn(struct) ->
-                Date.day_of_week(struct.for_date) == 7
-              end) do
-                insert_hours_slept(data, list, 7)
-              else
-                List.insert_at(list, 0, 0)
-              end
+    if Enum.any?(data, fn(struct) ->
+      Date.day_of_week(struct.for_date) == 7
+    end) do
+      hours_slept = Enum.filter(data, fn struct ->
+                  Date.day_of_week(struct.for_date) == 7 end)
+                  |> Enum.at(0)
+                  |> Map.get(:hours_slept)
+      List.insert_at(list, 0, hours_slept)
+    else
+      List.insert_at(list, 0, 0)
+    end
   end
 
   defp format_hours_list(data, list, n) do

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -19,7 +19,11 @@ defmodule Healthlocker.SleepTrackerView do
     past_week = get_past_week(data, date)
     total_slept = Enum.map(past_week, fn struct -> String.to_float(struct.hours_slept) end)
       |> Enum.reduce(0, fn(x, acc) -> x + acc end)
-    total_slept / Kernel.length(past_week)
+    if Kernel.length(past_week) == 0 do
+      0
+    else
+      total_slept / Kernel.length(past_week)
+    end
   end
 
   def format_sleep_data(data, from_date) do

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -6,12 +6,12 @@ defmodule Healthlocker.SleepTrackerView do
     Enum.filter(data, fn struct ->
       Date.compare(struct.for_date, end_date) != :gt
       and
-      Date.compare(struct.for_date, last_week(end_date)) == :gt
+      Date.compare(struct.for_date, last_week(end_date)) != :lt
     end)
   end
 
   defp last_week(end_date) do
-    Timex.shift(end_date, days: -7)
+    Timex.shift(end_date, days: -6)
   end
 
   def get_week_average(data, from_date) do
@@ -26,12 +26,42 @@ defmodule Healthlocker.SleepTrackerView do
     end
   end
 
-  def format_sleep_data(data, from_date) do
+  def format_sleep_hours(data, from_date) do
     {:ok, date} = Date.from_iso8601(from_date)
     week_data = get_past_week(data, date)
     format_hours_list(week_data, [], 1)
     |> Enum.join(",")
   end
+
+  def format_sleep_dates(end_date) do
+   {:ok, date} = Date.from_iso8601(end_date)
+   start_date = last_week(date)
+   format_dates_list(start_date, [], 1)
+   |> Enum.join(",")
+ end
+
+ defp format_dates_list(date, list, 7) do
+   day_of_week = if Date.day_of_week(date) == 7 do
+     0
+   else
+     Date.day_of_week(date)
+   end
+   day_month = day_month(date)
+   List.insert_at(list, day_of_week, day_month)
+ end
+
+ defp format_dates_list(date, list, n) do
+   # add start date to list at index == day of week_data
+   day_of_week = if Date.day_of_week(date) == 7 do
+     0
+   else
+     Date.day_of_week(date)
+   end
+   day_month = day_month(date)
+   new_list = List.insert_at(list, day_of_week, day_month)
+   new_date = Timex.shift(date, days: 1)
+   format_dates_list(new_date, new_list, n + 1)
+ end
 
   defp format_hours_list(data, list, 7) do
     # add hours to front of list

--- a/web/views/sleep_tracker_view.ex
+++ b/web/views/sleep_tracker_view.ex
@@ -92,10 +92,25 @@ defmodule Healthlocker.SleepTrackerView do
 
   defp insert_hours_slept(data, list, n) do
     hours_slept = Enum.filter(data, fn struct ->
-                  Date.day_of_week(struct.for_date) == n end)
-                  |> Enum.at(0)
-                  |> Map.get(:hours_slept)
+                Date.day_of_week(struct.for_date) == n end)
+                |> Enum.at(0)
+                |> Map.get(:hours_slept)
 
     List.insert_at(list, n - 1, hours_slept)
+  end
+
+  defp day_month(date) do
+    day = if date.day < 10 do
+      "0" <> Integer.to_string(date.day)
+    else
+      Integer.to_string(date.day)
+    end
+
+    month = if date.month < 10 do
+      "0" <> Integer.to_string(date.month)
+    else
+      Integer.to_string(date.month)
+    end
+    day <> "/" <>month
   end
 end


### PR DESCRIPTION
For #382 

Data can be viewed for previous or next 7 days
Date has been added to label on x-axis (otherwise it was unclear which Tuesday was meant for what date when scrolling through over time).