### PR TITLE
Fixes error outlines

### DIFF
--- a/test/controllers/account_controller_test.exs
+++ b/test/controllers/account_controller_test.exs
@@ -99,7 +99,7 @@ defmodule Healthlocker.AccountControllerTest do
 
     test "does not update when security answer is incorrect", %{conn: conn} do
       conn = put conn, account_path(conn, :update_security), user: @wrong_security_answer
-      assert redirected_to(conn) == account_path(conn, :edit_security)
+      assert html_response(conn, 200) =~ "Current security question"
       assert get_flash(conn, :error) == "Security answer does not match"
     end
 
@@ -115,7 +115,7 @@ defmodule Healthlocker.AccountControllerTest do
 
     test "does not update when current password is incorrect", %{conn: conn} do
       conn = put conn, account_path(conn, :update_password), user: @wrong_password
-      assert redirected_to(conn) == account_path(conn, :edit_password)
+      assert html_response(conn, 200) =~ "Current password"
       assert get_flash(conn, :error) == "Incorrect current password"
     end
 

--- a/test/views/component_view_test.exs
+++ b/test/views/component_view_test.exs
@@ -1,6 +1,36 @@
 defmodule Healthlocker.ComponentViewTest do
   use Healthlocker.ConnCase, async: true
-  alias Healthlocker.ComponentView
+  alias Healthlocker.{ComponentView,User}
+
+  # @valid_changeset <action: nil, changes: %{}, errors: [], valid?: false>
+  describe "changeset with and without errors" do
+    setup do
+      start_changeset = User.password_changeset(%User{})
+      error_changeset = start_changeset
+                      |> Ecto.Changeset.add_error(:password_check, "Does not match")
+
+      {:ok, start_changeset: start_changeset, error_changeset: error_changeset,
+    full_changeset: %{error_changeset | action: :update}}
+    end
+
+    test "highlight_errors gives new class when there are errors & action", %{full_changeset: full_changeset} do
+      actual = ComponentView.highlight_errors(full_changeset, :password_check)
+      expected = "hl-input-error hl-bg-error"
+      assert actual == expected
+    end
+
+    test "highlight_errors gives empty string when no errors or action", %{start_changeset: start_changeset} do
+      actual = ComponentView.highlight_errors(start_changeset, :password)
+      expected = ""
+      assert actual == expected
+    end
+
+    test "highlight_errors gives empty string when errors but no action", %{error_changeset: error_changeset} do
+      actual = ComponentView.highlight_errors(error_changeset, :password)
+      expected = ""
+      assert actual == expected
+    end
+  end
 
   test "get_options returns a list of questions" do
     actual = ComponentView.get_options("security_questions")

--- a/web/controllers/account_controller.ex
+++ b/web/controllers/account_controller.ex
@@ -71,8 +71,8 @@ defmodule Healthlocker.AccountController do
     user_id = conn.assigns.current_user.id
     user = Repo.get!(User, user_id)
 
+    changeset = User.security_question(user, user_params)
     if user_params["security_check"] == user.security_answer do
-      changeset = User.security_question(user, user_params)
 
       case Repo.update(changeset) do
         {:ok, _params} ->
@@ -84,9 +84,13 @@ defmodule Healthlocker.AccountController do
                     action: account_path(conn, :update_security))
       end
     else
+      changeset = changeset
+      |> Ecto.Changeset.add_error(:security_check, "Does not match")
+
       conn
       |> put_flash(:error, "Security answer does not match")
-      |> redirect(to: account_path(conn, :edit_security))
+      |> render("edit_security.html", changeset: %{changeset | action: :update}, user: user,
+                action: account_path(conn, :update_security))
     end
   end
 

--- a/web/controllers/account_controller.ex
+++ b/web/controllers/account_controller.ex
@@ -106,9 +106,9 @@ defmodule Healthlocker.AccountController do
     user_id = conn.assigns.current_user.id
     user = Repo.get!(User, user_id)
 
+    changeset = User.update_password(user, user_params)
     case Healthlocker.Auth.check_password(conn, user_id, user_params["password_check"], repo: Repo) do
       {:ok, conn} ->
-        changeset = User.update_password(user, user_params)
 
         case Repo.update(changeset) do
           {:ok, _params} ->
@@ -120,9 +120,13 @@ defmodule Healthlocker.AccountController do
                          action: account_path(conn, :update_password)
         end
       {:error, _reason, conn} ->
+        changeset = changeset
+        |> Ecto.Changeset.add_error(:password_check, "Does not match")
+        
         conn
         |> put_flash(:error, "Incorrect current password")
-        |> redirect(to: account_path(conn, :edit_password))
+        |> render("edit_password.html", changeset: %{changeset | action: :update},
+                user: user, action: account_path(conn, :update_password))
     end
   end
 

--- a/web/templates/account/edit_security.html.eex
+++ b/web/templates/account/edit_security.html.eex
@@ -4,7 +4,6 @@
   <p class="b mt3">Current security question</p>
   <%= @user.security_question %>
 
-
   <%= form_for @changeset, @action, fn f -> %>
     <input name="_method" type="hidden" value="put" />
     <div class="pb4 mt2">

--- a/web/templates/sleep_tracker/form.html.eex
+++ b/web/templates/sleep_tracker/form.html.eex
@@ -1,15 +1,11 @@
 <div class="br2 mv4 center">
   <%= form_for @changeset, @action, fn f -> %>
-  <%= if @changeset.action do %>
-    <div class="alert alert-danger">
-      <p>Oops, something went wrong! Please check the errors.</p>
-    </div>
-  <% end %>
 
   <div class="form-group">
     <%= label f, "Total hours sleep:", class: "f5 b db mb2" %>
     <%= select f, :hours_slept, Healthlocker.ComponentView.get_options("hours_slept"),
-      class: "pa3 input-reset bn hl-bg-grey w-100" %>
+      class: "pa3 input-reset bn hl-bg-grey w-100 " <>
+      Healthlocker.ComponentView.highlight_errors(@changeset, :hours_slept) %>
     <span class="hl-pink"><%= error_tag f, :hours_slept %></span>
   </div>
 

--- a/web/templates/user/form.html.eex
+++ b/web/templates/user/form.html.eex
@@ -4,11 +4,6 @@
 </div>
 <div class="br2 mv3 center">
   <%= form_for @changeset, @action, fn f -> %>
-  <%= if @changeset.action do %>
-    <div class="b--hl-pink br3 hl-bg-error center tc pv2 pv3-l mh4-l">
-      <p>Oops, something went wrong! Please check the errors.</p>
-    </div>
-  <% end %>
 
   <div class="form-group">
     <%= label f, "Name (optional)", class: "f5 b db mb2" %>

--- a/web/templates/user/signup2.html.eex
+++ b/web/templates/user/signup2.html.eex
@@ -2,11 +2,6 @@
   <h3 class="tc">Sign up</h3>
   <%= form_for @changeset, @action, fn f -> %>
     <input name="_method" type="hidden" value="put" />
-    <%= if @changeset.action do %>
-      <div class="b--hl-pink br3 hl-bg-error center tc pv2 pv3-l mh4-l">
-        <p>Oops, something went wrong! Please check the errors.</p>
-      </div>
-    <% end %>
 
     <div class="form-group">
       <%= label f, :password, class: "f5 b db mb2" %>

--- a/web/templates/user/signup3.html.eex
+++ b/web/templates/user/signup3.html.eex
@@ -16,11 +16,6 @@
 
   <%= form_for @changeset, @action, fn f -> %>
     <input name="_method" type="hidden" value="put" />
-    <%= if @changeset.action do %>
-      <div class="b--hl-pink br3 hl-bg-error center tc pv2 pv3-l mh4-l">
-        <p>Oops, something went wrong! Please check the errors.</p>
-      </div>
-    <% end %>
 
     <div class="form-group">
       <%= checkbox f, :terms_conditions, class: "checkbox" %>

--- a/web/views/component_view.ex
+++ b/web/views/component_view.ex
@@ -71,8 +71,8 @@ defmodule Healthlocker.ComponentView do
   end
 
   def highlight_errors(changeset, field) do
-    if Keyword.has_key?(changeset.errors, field) do
-      "hl-input-error"
+    if Keyword.has_key?(changeset.errors, field) && changeset.action do
+      "hl-input-error hl-bg-error"
     else
       ""
     end


### PR DESCRIPTION
#360

The error outline was showing when the page first loaded. There also needed to be a check for changeset actions before adding the class. 

Additionally, some fields were not showing the error because they were not part of the changesets (and instead were a password/security question check). This was fixed by adding an error and an action to the changeset in the controller. 