### PR TITLE
Create narrow menu display on desktop

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -46,7 +46,6 @@ select:focus {
 .sidenav {
     width: 0;
     transition: 0.5s;
-    padding-top: 60px;
 }
 
 .sidenav a {

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -38,6 +38,7 @@
         <nav class="sidenav h-100 absolute z-1 top-0 left-0 hl-bg-dark-blue overflow-x-hidden tc" id="my-sidenav">
           <%= img_tag("/images/x_icon.svg", id: "close-nav", class: "w2") %>
           <%= link "Home", to: page_path(@conn, :index), class: "pa3 f3 white-80 db hover-white" %>
+          <%= img_tag("/images/x_icon.svg", id: "close-nav", class: "w2 mt5") %>
           <%= link "Home", to: page_path(@conn, :index), class: "pa3 pt5-l f3 white-80 db hover-white" %>
           <%= link "About", to: page_path(@conn, :show, "about"), class: "pa3 f3 white-80 db hover-white" %>
           <%= if @current_user do %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -35,9 +35,7 @@
           </nav>
         </header>
 
-        <nav class="sidenav h-100 absolute z-1 top-0 left-0 hl-bg-dark-blue overflow-x-hidden tc" id="my-sidenav">
-          <%= img_tag("/images/x_icon.svg", id: "close-nav", class: "w2") %>
-          <%= link "Home", to: page_path(@conn, :index), class: "pa3 f3 white-80 db hover-white" %>
+        <nav class="sidenav h-100 absolute z-1 top-0 left-0 hl-bg-dark-blue overflow-x-hidden tc measure-narrow-l br-l b--white" id="my-sidenav">
           <%= img_tag("/images/x_icon.svg", id: "close-nav", class: "w2 mt5") %>
           <%= link "Home", to: page_path(@conn, :index), class: "pa3 pt5-l f3 white-80 db hover-white" %>
           <%= link "About", to: page_path(@conn, :show, "about"), class: "pa3 f3 white-80 db hover-white" %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -57,7 +57,7 @@
                                 to: login_path(@conn, :delete, @current_user),
                                 method: "delete" %>
           <% end %>
-          <%= link "Get support", to: support_path(@conn, :index), class: "mt3 mh5 mh6-m mh7-l hl-bg-pink pv2 f3 white-80 db hover-white" %>
+          <%= link "Get support", to: support_path(@conn, :index), class: "mt3 mh5 mh6-m hl-bg-pink pv2 f3 white-80 db hover-white" %>
         </nav>
 
         <main id="body">

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -38,6 +38,7 @@
         <nav class="sidenav h-100 absolute z-1 top-0 left-0 hl-bg-dark-blue overflow-x-hidden tc" id="my-sidenav">
           <%= img_tag("/images/x_icon.svg", id: "close-nav", class: "w2") %>
           <%= link "Home", to: page_path(@conn, :index), class: "pa3 f3 white-80 db hover-white" %>
+          <%= link "Home", to: page_path(@conn, :index), class: "pa3 pt5-l f3 white-80 db hover-white" %>
           <%= link "About", to: page_path(@conn, :show, "about"), class: "pa3 f3 white-80 db hover-white" %>
           <%= if @current_user do %>
             <%= link "Toolkit",  class: "pa3 f3 white-80 db hover-white",


### PR DESCRIPTION
- Rearranges padding so there is no whitespace beneath the footer. 
- Removes unneeded margin on 'Get support' so that the text and pink background show as they should.
- Adds white border on the right on desktop screens (as per the design).
- Reduces the width of the menu display for desktop screens.
- Spaces the links as per the design for desktop with a little extra space between the 'X' and home in comparison to on mobile.

All for #448 