### PR TITLE
Seeds fix

### DIFF
--- a/priv/repo/user_only_seeds.exs
+++ b/priv/repo/user_only_seeds.exs
@@ -1,0 +1,34 @@
+alias Healthlocker.{Repo, User}
+
+Repo.insert!(%User{
+  email: "evan@email.com",
+  password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
+  name: "Evan",
+  phone_number: "07512 345 678",
+  security_question: "Name of first boss?",
+  security_answer: "Betty",
+  data_access: true,
+  role: "slam_user"
+})
+
+Repo.insert!(%User{
+  email: "lisa@email.com",
+  password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
+  name: "Lisa",
+  phone_number: "07512 678 345",
+  security_question: "Name of first boss?",
+  security_answer: "Betty",
+  data_access: false,
+  role: "slam_user"
+})
+
+Repo.insert!(%User{
+  email: "angela@email.com",
+  password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
+  name: "Angela",
+  phone_number: "07519 283 475",
+  security_question: "Name of first boss?",
+  security_answer: "Betty",
+  data_access: false,
+  role: "slam_user"
+})

--- a/test/controllers/caseload_controller_test.exs
+++ b/test/controllers/caseload_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Healthlocker.CaseloadControllerTest do
   use Healthlocker.ConnCase
 
-  alias Healthlocker.{EPJSTeamMember, EPJSUser, ReadOnlyRepo, User}
+  alias Healthlocker.{EPJSClinician, ReadOnlyRepo, User}
 
   describe "current_user is assigned in the session" do
     setup do
@@ -13,6 +13,12 @@ defmodule Healthlocker.CaseloadControllerTest do
         security_question: "Question?",
         security_answer: "Answer"
       } |> Repo.insert
+
+      %EPJSClinician{
+        GP_Code: "NyNsn50mPQPFZYn7",
+        First_Name: "Robert",
+        Last_Name: "MacMurray"
+      } |> ReadOnlyRepo.insert
 
       {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123456)) }
     end

--- a/web/controllers/caseload_controller.ex
+++ b/web/controllers/caseload_controller.ex
@@ -1,15 +1,17 @@
 defmodule Healthlocker.CaseloadController do
   use Healthlocker.Web, :controller
 
-  alias Healthlocker.{EPJSTeamMember, EPJSUser, ReadOnlyRepo, User}
+  alias Healthlocker.{EPJSTeamMember, EPJSUser,
+                      EPJSClinician, ReadOnlyRepo, User}
 
   def index(conn, _params) do
     # only have one known clinician right now, so using this to get info
     # will need to grab the clinician_id from the token used to go from
     # epjs to HL
-    clinician_id = 63
+    clinician = ReadOnlyRepo.one(from c in EPJSClinician,
+                where: c."GP_Code" == "NyNsn50mPQPFZYn7")
     patient_ids = EPJSTeamMember
-                  |> EPJSTeamMember.patient_ids(clinician_id)
+                  |> EPJSTeamMember.patient_ids(clinician.id)
                   |> ReadOnlyRepo.all
 
     hl_users = patient_ids


### PR DESCRIPTION
Fix seeds & caseload index so it can be used in prod. If the data was run for priv/repo/seeds.exs there would be a bunch of unnecessary data (with lorem ipsum posts), so the users are now in separate file