### PR TITLE
Find the service user

### DIFF
--- a/web/controllers/care_team/room_controller.ex
+++ b/web/controllers/care_team/room_controller.ex
@@ -1,5 +1,5 @@
 defmodule Healthlocker.CareTeam.RoomController do
-  alias Healthlocker.{Message}
+  alias Healthlocker.{Message, User}
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id}) do

--- a/web/controllers/care_team/room_controller.ex
+++ b/web/controllers/care_team/room_controller.ex
@@ -1,10 +1,10 @@
 defmodule Healthlocker.CareTeam.RoomController do
-  alias Healthlocker.{Message, Room}
+  alias Healthlocker.{Message}
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id}) do
     room = Repo.get! assoc(conn.assigns.current_user, :rooms), id
-    service_user = service_user_for(conn.assigns.current_user)
+    service_user = User.service_user_for(conn.assigns.current_user)
 
     messages = Repo.all from m in Message,
       where: m.room_id == ^room.id,
@@ -17,15 +17,5 @@ defmodule Healthlocker.CareTeam.RoomController do
     |> assign(:messages, messages)
     |> assign(:current_user_id, conn.assigns.current_user.id)
     |> render("show.html")
-  end
-
-  defp service_user_for(carer) do
-    if carer.slam_id do
-      carer
-    else
-      carer = carer |> Repo.preload(:caring)
-      [service_user | _] = carer.caring
-      service_user
-    end
   end
 end

--- a/web/controllers/caseload/room_controller.ex
+++ b/web/controllers/caseload/room_controller.ex
@@ -10,8 +10,9 @@ defmodule Healthlocker.Caseload.RoomController do
       preload: [:user]
 
     user = Repo.get!(User, user_id)
+    service_user = User.service_user_for(user)
     slam_user = ReadOnlyRepo.one(from e in EPJSUser,
-                where: e."Patient_ID" == ^user.slam_id)
+                where: e."Patient_ID" == ^service_user.slam_id)
 
     conn
     |> assign(:service_user, nil)

--- a/web/controllers/caseload/user_controller.ex
+++ b/web/controllers/caseload/user_controller.ex
@@ -6,18 +6,18 @@ defmodule Healthlocker.Caseload.UserController do
   def show(conn, %{"id" => id, "section" => section}) do
     user = Repo.get!(User, id)
     room = Repo.one! assoc(user, :rooms)
-
+    service_user = User.service_user_for(user)
     slam_user = ReadOnlyRepo.one(from e in EPJSUser,
-                where: e."Patient_ID" == ^user.slam_id)
+                where: e."Patient_ID" == ^service_user.slam_id)
     address = ReadOnlyRepo.one(from e in EPJSPatientAddressDetails,
-                    where: e."Patient_ID" == ^user.slam_id)
+                    where: e."Patient_ID" == ^service_user.slam_id)
     goals = Goal
           |> Goal.get_goals(id)
           |> Repo.all
     strategies = Post
                 |> Post.get_coping_strategies(id)
                 |> Repo.all
-    render(conn, String.to_atom(section), user: user, slam_user: slam_user,
+    render(conn, String.to_atom(section), user: service_user, slam_user: slam_user,
           address: address, goals: goals, strategies: strategies, room: room)
   end
 

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -130,4 +130,18 @@ defmodule Healthlocker.User do
         changeset
     end
   end
+
+  @moduledoc """
+  If the User has a slam_id then they're already a service user. However, if the
+  user is a carer, then their service user is the user they care for.
+  """
+  def service_user_for(user) do
+    if user.slam_id do
+      user
+    else
+      carer = user |> Healthlocker.Repo.preload(:caring)
+      [service_user | _] = carer.caring
+      service_user
+    end
+  end
 end


### PR DESCRIPTION
In Healthlocker a `User` can have a few different roles:
- Service User (linked to slam)
- Carer (linked to a service user)

This PR adds a helper `User. service_user_for/1` which will return the Service User, for a given User. We then use this in the Caseload controllers to find the correct service user, before querying slam.