### PR TITLE
Read receipts

### DIFF
--- a/priv/repo/migrations/20170512144937_create_read_receipt.exs
+++ b/priv/repo/migrations/20170512144937_create_read_receipt.exs
@@ -1,0 +1,15 @@
+defmodule Healthlocker.Repo.Migrations.CreateReadReceipt do
+  use Ecto.Migration
+
+  def change do
+    create table(:read_receipts) do
+      add :message_id, references(:messages, on_delete: :nothing), null: false
+      add :user_id, references(:users, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:read_receipts, [:message_id], unique: true)
+    create index(:read_receipts, [:user_id])
+  end
+end

--- a/priv/repo/migrations/20170512144937_create_read_receipt.exs
+++ b/priv/repo/migrations/20170512144937_create_read_receipt.exs
@@ -5,6 +5,7 @@ defmodule Healthlocker.Repo.Migrations.CreateReadReceipt do
     create table(:read_receipts) do
       add :message_id, references(:messages, on_delete: :nothing), null: false
       add :user_id, references(:users, on_delete: :nothing), null: false
+      add :read, :boolean
 
       timestamps()
     end

--- a/test/models/read_receipt_test.exs
+++ b/test/models/read_receipt_test.exs
@@ -3,7 +3,7 @@ defmodule Healthlocker.ReadReceiptTest do
 
   alias Healthlocker.ReadReceipt
 
-  @valid_attrs %{message_id: 1, user_id: 1}
+  @valid_attrs %{message_id: 1, user_id: 1, read: true}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/models/read_receipt_test.exs
+++ b/test/models/read_receipt_test.exs
@@ -1,0 +1,18 @@
+defmodule Healthlocker.ReadReceiptTest do
+  use Healthlocker.ModelCase
+
+  alias Healthlocker.ReadReceipt
+
+  @valid_attrs %{message_id: 1, user_id: 1}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = ReadReceipt.changeset(%ReadReceipt{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = ReadReceipt.changeset(%ReadReceipt{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -30,7 +30,7 @@ defmodule Healthlocker.RoomChannel do
   end
 
   defp broadcast_message(socket, message) do
-    message = Repo.preload(message, :user)
+    message = Repo.preload(message, [:user, :read_receipt])
     rendered_message = Phoenix.View.render_to_string(MessageView, "_message.html", message: message, current_user_id: nil)
     broadcast!(socket, "msg:created", %{template: rendered_message, id: message.id, message_user_id: socket.assigns.user_id})
   end

--- a/web/controllers/care_team/room_controller.ex
+++ b/web/controllers/care_team/room_controller.ex
@@ -1,5 +1,5 @@
 defmodule Healthlocker.CareTeam.RoomController do
-  alias Healthlocker.{Message, Room}
+  alias Healthlocker.{Message}
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id}) do

--- a/web/controllers/care_team/room_controller.ex
+++ b/web/controllers/care_team/room_controller.ex
@@ -8,7 +8,7 @@ defmodule Healthlocker.CareTeam.RoomController do
     messages = Repo.all from m in Message,
       where: m.room_id == ^room.id,
       order_by: [asc: :inserted_at, asc: :id],
-      preload: [:user]
+      preload: [:user, :read_receipt]
 
     conn
     |> assign(:room, room)

--- a/web/controllers/caseload/read_receipt_controller.ex
+++ b/web/controllers/caseload/read_receipt_controller.ex
@@ -1,0 +1,33 @@
+defmodule Healthlocker.Caseload.ReadReceiptController do
+  use Healthlocker.Web, :controller
+  alias Healthlocker.{Message, ReadReceipt}
+
+  def create(conn, %{"message_id" => message_id, "read_receipt" => read_receipt_params}) do
+    message = find_message(message_id)
+
+    # Check params for read == true
+    changeset = ReadReceipt.changeset(%ReadReceipt{}, %{
+      message_id: message.id,
+      user_id: conn.assigns.current_user.id,
+      read: true
+    })
+
+    case Repo.insert(changeset) do
+      {:ok, read_receipt} ->
+        conn
+        |> put_flash(:info, "Read successful")
+        |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))
+      {:error, changeset} ->
+        require IEx; IEx.pry
+
+        conn
+        |> put_flash(:error, "Something went wrong")
+        |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))
+    end
+  end
+
+  defp find_message(message_id) do
+    # user.rooms.message.find(message_id)
+    Repo.get(Message, message_id)
+  end
+end

--- a/web/controllers/caseload/read_receipt_controller.ex
+++ b/web/controllers/caseload/read_receipt_controller.ex
@@ -2,10 +2,9 @@ defmodule Healthlocker.Caseload.ReadReceiptController do
   use Healthlocker.Web, :controller
   alias Healthlocker.{Message, ReadReceipt}
 
-  def create(conn, %{"message_id" => message_id, "read_receipt" => read_receipt_params}) do
+  def create(conn, %{"message_id" => message_id, "read_receipt" => _read_receipt_params}) do
     message = find_message(message_id)
 
-    # Check params for read == true
     changeset = ReadReceipt.changeset(%ReadReceipt{}, %{
       message_id: message.id,
       user_id: conn.assigns.current_user.id,
@@ -13,13 +12,11 @@ defmodule Healthlocker.Caseload.ReadReceiptController do
     })
 
     case Repo.insert(changeset) do
-      {:ok, read_receipt} ->
+      {:ok, _read_receipt} ->
         conn
         |> put_flash(:info, "Read successful")
         |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))
-      {:error, changeset} ->
-        require IEx; IEx.pry
-
+      {:error, _changeset} ->
         conn
         |> put_flash(:error, "Something went wrong")
         |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))

--- a/web/controllers/caseload/read_receipt_controller.ex
+++ b/web/controllers/caseload/read_receipt_controller.ex
@@ -11,15 +11,22 @@ defmodule Healthlocker.Caseload.ReadReceiptController do
       read: true
     })
 
+    path =
+      conn
+      |> Plug.Conn.get_req_header("referer")
+      |> List.first
+      |> URI.parse
+      |> Map.get(:path)
+
     case Repo.insert(changeset) do
       {:ok, _read_receipt} ->
         conn
         |> put_flash(:info, "Read successful")
-        |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))
+        |> redirect(to: path)
       {:error, _changeset} ->
         conn
         |> put_flash(:error, "Something went wrong")
-        |> redirect(to: caseload_user_room_path(conn, :show, 5, 1))
+        |> redirect(to: path)
     end
   end
 

--- a/web/controllers/caseload/room_controller.ex
+++ b/web/controllers/caseload/room_controller.ex
@@ -1,5 +1,5 @@
 defmodule Healthlocker.Caseload.RoomController do
-  alias Healthlocker.{EPJSUser, Message, ReadReceipt, Room, User}
+  alias Healthlocker.{EPJSUser, Message, Room, User}
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id, "user_id" => user_id}) do

--- a/web/controllers/caseload/room_controller.ex
+++ b/web/controllers/caseload/room_controller.ex
@@ -7,7 +7,7 @@ defmodule Healthlocker.Caseload.RoomController do
     messages = Repo.all from m in Message,
       where: m.room_id == ^room.id,
       order_by: [asc: :inserted_at, asc: :id],
-      preload: [:user]
+      preload: [:user, :read_receipt]
 
     user = Repo.get!(User, user_id)
     slam_user = find_slam_user(user)

--- a/web/controllers/caseload/room_controller.ex
+++ b/web/controllers/caseload/room_controller.ex
@@ -1,5 +1,5 @@
 defmodule Healthlocker.Caseload.RoomController do
-  alias Healthlocker.{EPJSUser, Message, Room, User}
+  alias Healthlocker.{EPJSUser, Message, ReadReceipt, Room, User}
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id, "user_id" => user_id}) do
@@ -10,8 +10,7 @@ defmodule Healthlocker.Caseload.RoomController do
       preload: [:user]
 
     user = Repo.get!(User, user_id)
-    slam_user = ReadOnlyRepo.one(from e in EPJSUser,
-                where: e."Patient_ID" == ^user.slam_id)
+    slam_user = find_slam_user(user)
 
     conn
     |> assign(:room, room)
@@ -20,5 +19,13 @@ defmodule Healthlocker.Caseload.RoomController do
     |> assign(:user, user)
     |> assign(:current_user_id, conn.assigns.current_user.id)
     |> render("show.html")
+  end
+
+  defp find_slam_user(user) do
+    if user.slam_id do
+      ReadOnlyRepo.one(from e in EPJSUser, where: e."Patient_ID" == ^user.slam_id)
+    else
+      nil
+    end
   end
 end

--- a/web/models/message.ex
+++ b/web/models/message.ex
@@ -4,6 +4,7 @@ defmodule Healthlocker.Message do
   schema "messages" do
     field :body, :string
     field :name, :string
+    has_one :read_receipt, Healtlocker.ReadReceipt
     belongs_to :user, Healthlocker.User
     belongs_to :room, Healthlocker.Room
 

--- a/web/models/message.ex
+++ b/web/models/message.ex
@@ -4,7 +4,7 @@ defmodule Healthlocker.Message do
   schema "messages" do
     field :body, :string
     field :name, :string
-    has_one :read_receipt, Healtlocker.ReadReceipt
+    has_one :read_receipt, Healthlocker.ReadReceipt
     belongs_to :user, Healthlocker.User
     belongs_to :room, Healthlocker.Room
 

--- a/web/models/read_receipt.ex
+++ b/web/models/read_receipt.ex
@@ -1,0 +1,18 @@
+defmodule Healthlocker.ReadReceipt do
+  use Healthlocker.Web, :model
+
+  schema "read_receipts" do
+    belongs_to :message, Healthlocker.Message
+    belongs_to :user, Healthlocker.User
+
+    timestamps()
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:message_id, :user_id])
+    |> validate_required([:message_id, :user_id])
+    |> assoc_constraint(:message)
+    |> assoc_constraint(:user)
+  end
+end

--- a/web/models/read_receipt.ex
+++ b/web/models/read_receipt.ex
@@ -4,14 +4,15 @@ defmodule Healthlocker.ReadReceipt do
   schema "read_receipts" do
     belongs_to :message, Healthlocker.Message
     belongs_to :user, Healthlocker.User
+    field :read, :boolean
 
     timestamps()
   end
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:message_id, :user_id])
-    |> validate_required([:message_id, :user_id])
+    |> cast(params, [:message_id, :user_id, :read])
+    |> validate_required([:message_id, :user_id, :read])
     |> assoc_constraint(:message)
     |> assoc_constraint(:user)
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -27,6 +27,7 @@ defmodule Healthlocker.User do
 
     many_to_many :rooms, Healthlocker.Room, join_through: "user_rooms"
     has_many :messages, Healthlocker.Message
+    has_many :read_receipts, Healthlocker.ReadReceipt
 
     timestamps()
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -61,7 +61,7 @@ defmodule Healthlocker.Router do
       end
 
       resources "/messages", MessageController, only: [:show] do
-        resources "/read-receipt", ReadReceiptController, singleton: true
+        resources "/read-receipt", ReadReceiptController, singleton: true, only: [:create]
       end
     end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -59,6 +59,10 @@ defmodule Healthlocker.Router do
       resources "/users", UserController, only: [:show] do
         resources "/rooms", RoomController, only: [:show]
       end
+
+      resources "/messages", MessageController, only: [:show] do
+        resources "/read-receipt", ReadReceiptController, singleton: true
+      end
     end
 
     resources "/slam", SlamController, only: [:new, :create]

--- a/web/static/js/room.js
+++ b/web/static/js/room.js
@@ -25,21 +25,15 @@ let Room = {
       }
     })
 
-    // let inputs = msgContainer.getElementsByTagName("input")
-    // for (var input in inputs) {
-    //   console.log(input);
-    // }
-    // var checkbox = document.querySelector("input[name=checkbox]");
-    let checkbox = document.getElementById("read_receipt_read")
-    checkbox.onchange = function(e) {
-      if (this.checked) {
-        console.log("Checked!");
-        checkbox.form.submit()
-      } else {
-        console.log("Unchecked!");
+    // Find all the checkboxes, ticking these will mark a message as read.
+    let checkboxes = document.querySelectorAll("input[type=checkbox]")
+    for (let checkbox of checkboxes) {
+      checkbox.onchange = function(e) {
+        if (this.checked) {
+          checkbox.form.submit()
+        }
       }
     }
-
 
     roomChannel.on("msg:created", (resp) => {
       this.renderMessage(msgContainer, resp)

--- a/web/static/js/room.js
+++ b/web/static/js/room.js
@@ -25,6 +25,22 @@ let Room = {
       }
     })
 
+    // let inputs = msgContainer.getElementsByTagName("input")
+    // for (var input in inputs) {
+    //   console.log(input);
+    // }
+    // var checkbox = document.querySelector("input[name=checkbox]");
+    let checkbox = document.getElementById("read_receipt_read")
+    checkbox.onchange = function(e) {
+      if (this.checked) {
+        console.log("Checked!");
+        checkbox.form.submit()
+      } else {
+        console.log("Unchecked!");
+      }
+    }
+
+
     roomChannel.on("msg:created", (resp) => {
       this.renderMessage(msgContainer, resp)
     })

--- a/web/templates/care_team/message/show.html.eex
+++ b/web/templates/care_team/message/show.html.eex
@@ -1,0 +1,6 @@
+<div class="dib w-100">
+  <%= link "Messages", to: care_team_message_path(@conn, :show), class: "link w-50 dib fl black tc pv1 bg-white mv4 bb b--hl-aqua" %>
+  <%= link "Contacts", to: care_team_contact_path(@conn, :show), class: "link w-50 dib fl black tc pv1 bg-white mv4" %>
+</div>
+
+<%= render Healthlocker.RoomView, "_room.html", assigns %>

--- a/web/templates/caseload/index.html.eex
+++ b/web/templates/caseload/index.html.eex
@@ -4,7 +4,7 @@
 <div class="cf">
   <%= for user <- @hl_users do %>
     <%= link to: caseload_user_path(@conn, :show, user),
-            class: "no-underline hl-dark-blue" do %>
+            class: "no-underline hl-dark-blue cf" do %>
       <div class="w-100 hl-bg-grey pa3 mv3 br3 hl-dark-blue">
         <p class="b di"><%= user.first_name <> " " <> user.last_name %></p><span class="fr hl-yellow fw9">></span>
       </div>
@@ -12,7 +12,7 @@
 
     <%= for carer <- user.carers do %>
       <%= link to: caseload_user_room_path(@conn, :show, carer, room_for(carer)),
-              class: "no-underline hl-dark-blue" do %>
+              class: "no-underline hl-dark-blue cf" do %>
         <div class="w-80 fr hl-bg-grey pa3 mv3 br3 hl-dark-blue">
           <p class="b di"><%= carer.first_name <> " " <> carer.last_name %> (carer)</p><span class="fr hl-yellow fw9">></span>
         </div>

--- a/web/templates/message/_message.html.eex
+++ b/web/templates/message/_message.html.eex
@@ -5,10 +5,14 @@
     <small class="white dib fr"><time><%= sent_at(@message) %></time></small>
   </p>
 
-  <%= if @message.read_receipt do %>
-    <small class="white dib fr pl1">Read</small>
-    <i class="fr fa fa-check white" aria-hidden="true"></i>
-  <% else %>
-    <%= render Healthlocker.ReadReceiptView, "_read_receipt.html", message: @message, changeset: Healthlocker.ReadReceipt.changeset(%Healthlocker.ReadReceipt{}, %{}), conn: @conn %>
+  <%= if @current_user_id && sent_by_user(@message) do %>
+    <%= if @message.read_receipt do %>
+      <small class="white dib fr pl1">Read</small>
+      <i class="fr fa fa-check white" aria-hidden="true"></i>
+    <% else %>
+      <%= if clinician?(@conn.assigns.current_user) do %>
+        <%= render Healthlocker.ReadReceiptView, "_read_receipt.html", message: @message, changeset: Healthlocker.ReadReceipt.changeset(%Healthlocker.ReadReceipt{}, %{}), conn: @conn %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/web/templates/message/_message.html.eex
+++ b/web/templates/message/_message.html.eex
@@ -5,5 +5,10 @@
     <small class="white dib fr"><time><%= sent_at(@message) %></time></small>
   </p>
 
-  <%= render Healthlocker.ReadReceiptView, "_read_receipt.html", message: @message, changeset: Healthlocker.ReadReceipt.changeset(%Healthlocker.ReadReceipt{}, %{}), conn: @conn %>
+  <%= if @message.read_receipt do %>
+    <small class="white dib fr pl1">Read</small>
+    <i class="fr fa fa-check white" aria-hidden="true"></i>
+  <% else %>
+    <%= render Healthlocker.ReadReceiptView, "_read_receipt.html", message: @message, changeset: Healthlocker.ReadReceipt.changeset(%Healthlocker.ReadReceipt{}, %{}), conn: @conn %>
+  <% end %>
 </div>

--- a/web/templates/message/_message.html.eex
+++ b/web/templates/message/_message.html.eex
@@ -4,4 +4,6 @@
     <%= @message.body %>
     <small class="white dib fr"><time><%= sent_at(@message) %></time></small>
   </p>
+
+  <%= render Healthlocker.ReadReceiptView, "_read_receipt.html", message: @message, changeset: Healthlocker.ReadReceipt.changeset(%Healthlocker.ReadReceipt{}, %{}), conn: @conn %>
 </div>

--- a/web/templates/read_receipt/_read_receipt.html.eex
+++ b/web/templates/read_receipt/_read_receipt.html.eex
@@ -1,4 +1,4 @@
 <%= form_for @changeset, caseload_message_read_receipt_path(@conn, :create, @message.id), fn f -> %>
-  <label>Reminder text</label>
+  <%= label f, :read %>
   <%= checkbox f, :read %>
 <% end %>

--- a/web/templates/read_receipt/_read_receipt.html.eex
+++ b/web/templates/read_receipt/_read_receipt.html.eex
@@ -1,0 +1,4 @@
+<%= form_for @changeset, caseload_message_read_receipt_path(@conn, :create, @message.id), fn f -> %>
+  <label>Reminder text</label>
+  <%= checkbox f, :read %>
+<% end %>

--- a/web/templates/room/_room.html.eex
+++ b/web/templates/room/_room.html.eex
@@ -1,6 +1,6 @@
 <%= content_tag :div, id: "message-feed", data: [room_id: @room.id, user_id: @current_user_id], class: "db ba b--hl-aqua br2 overflow-y-scroll overflow-x-hidden smooth-scroll mb3 ph3 pt2" do %>
   <%= for message <- @messages do %>
-    <%= render Healthlocker.MessageView, "_message.html", message: message, current_user_id: @current_user_id %>
+    <%= render Healthlocker.MessageView, "_message.html", message: message, current_user_id: @current_user_id, conn: @conn %>
   <% end %>
 <% end %>
 

--- a/web/views/message_view.ex
+++ b/web/views/message_view.ex
@@ -18,7 +18,6 @@ defmodule Healthlocker.MessageView do
   end
 
   def clinician?(user) do
-    # require IEx; IEx.pry() 
     user.role == "clinician"
   end
 

--- a/web/views/message_view.ex
+++ b/web/views/message_view.ex
@@ -13,6 +13,15 @@ defmodule Healthlocker.MessageView do
     Timex.from_now(message.inserted_at)
   end
 
+  def sent_by_user(message) do
+    message.user.role != "clinician"
+  end
+
+  def clinician?(user) do
+    # require IEx; IEx.pry() 
+    user.role == "clinician"
+  end
+
   @base_classes "w-80 br2 mb2 pa1 pa3-ns"
   @sender_classes "hl-bg-yellow fr"
   @receiver_classes "hl-bg-aqua fl"

--- a/web/views/read_receipt_view.ex
+++ b/web/views/read_receipt_view.ex
@@ -1,0 +1,3 @@
+defmodule Healthlocker.ReadReceiptView do
+  use Healthlocker.Web, :view 
+end


### PR DESCRIPTION
Adds the ability for clinicians to mark a message as having been read (#50 #51).

There is a current issue with the rendering of new messages. We currently render the message template server-side and broadcast it to clients. However, with the addition of read receipts that template is noticeably different depending upon whether it is for a clinician or service user / carer.

The solution to this is to broadcast json about the created message to all the connected clients and allow them to decide how to render the template. We were [initially](https://github.com/healthlocker/healthlocker/commit/bbcf99db0c25cde542fe73cdc14f5b76c23891c1#diff-ea714e4fa06ed136d22d6c9c224ca846) doing this, but switched to pure server-side rendering to keep things simple. 