### PR TITLE
Clinician flow

### DIFF
--- a/priv/read_only_repo/migrations/20170627095645_add_user_guid.exs
+++ b/priv/read_only_repo/migrations/20170627095645_add_user_guid.exs
@@ -1,0 +1,9 @@
+defmodule Healthlocker.ReadOnlyRepo.Migrations.AddUserGuid do
+  use Ecto.Migration
+
+  def change do
+    alter table(:mhlTeamMembers) do
+      add :User_Guid, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20170627103813_add_user_guid.exs
+++ b/priv/repo/migrations/20170627103813_add_user_guid.exs
@@ -1,0 +1,9 @@
+defmodule Healthlocker.Repo.Migrations.AddUserGuid do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :user_guid, :string
+    end
+  end
+end

--- a/test/controllers/caseload_controller_test.exs
+++ b/test/controllers/caseload_controller_test.exs
@@ -1,22 +1,44 @@
 defmodule Healthlocker.CaseloadControllerTest do
   use Healthlocker.ConnCase
 
-  alias Healthlocker.{EPJSTeamMember, EPJSPatientAddressDetails,
-                      EPJSUser, ReadOnlyRepo, User, UserRoom, Room}
+  alias Healthlocker.{EPJSTeamMember, ReadOnlyRepo, User}
 
-  describe "current_user is assigned in the session" do
+  describe "current_user is assigned in the session with epjs User_Guid" do
     setup do
       %User{
-        id: 123456,
-        first_name: "My",
-        last_name: "Name",
-        email: "abc@gmail.com",
+        id: 123457,
+        first_name: "Robert",
+        last_name: "MacMurray",
+        email: "robert_macmurray@nhs.co.uk",
         password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
         security_question: "Question?",
         security_answer: "Answer",
-        slam_id: 201
+        role: "clinician",
+        user_guid: "someotherrandomstring"
       } |> Repo.insert
 
+      %EPJSTeamMember{
+        Staff_ID: 12345678,
+        Patient_ID: 201,
+        Staff_Name: "Robert MacMurray",
+        Job_Title: "GP",
+        Team_Member_Role_Desc: "Care team lead",
+        Email: "robert_macmurray@nhs.co.uk",
+        User_Guid: "someotherrandomstring"
+      } |> ReadOnlyRepo.insert
+
+      %EPJSTeamMember{
+        Staff_ID: 326746,
+        Patient_ID: 20,
+        Staff_Name: "Other Person",
+        Job_Title: "GP",
+        Team_Member_Role_Desc: "Care team lead",
+        Email: "other_email@nhs.co.uk",
+        User_Guid: "randomstringtotestwith"
+      } |> ReadOnlyRepo.insert
+
+      {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123457)) }
+    end
       %User{
         id: 123457,
         first_name: "Robert",

--- a/test/controllers/caseload_controller_test.exs
+++ b/test/controllers/caseload_controller_test.exs
@@ -39,6 +39,34 @@ defmodule Healthlocker.CaseloadControllerTest do
 
       {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123457)) }
     end
+
+    test "GET /caseload", %{conn: conn} do
+      conn = get conn, caseload_path(conn, :index)
+      assert html_response(conn, 200) =~ "Caseload"
+    end
+
+    test "GET /caseload?=userData without HL user", %{conn: conn} do
+      # refute before and assert after to ensure HL user has been created
+      refute Repo.get_by(User, email: "other_email@nhs.co.uk")
+      conn = get conn, "/caseload?userData=UserName=other_email@nhs.co.uk&UserId=randomstringtotestwith&tokenexpiry=2017-06-23T11:15:53"
+      assert html_response(conn, 200) =~ "Caseload"
+      assert Repo.get_by(User, email: "other_email@nhs.co.uk")
+    end
+
+    test "GET /caseload?=userData with HL user", %{conn: conn} do
+      %User{
+        first_name: "Other",
+        last_name: "Person",
+        email: "other_email@nhs.co.uk",
+        password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
+        security_question: "Question?",
+        security_answer: "Answer",
+        user_guid: "randomstringtotestwith"
+      } |> Repo.insert
+      conn = get conn, "/caseload?userData=UserName=other_email@nhs.co.uk&UserId=randomstringtotestwith&tokenexpiry=2017-06-23T11:15:53"
+      assert html_response(conn, 200) =~ "Caseload"
+    end
+  end
       %User{
         id: 123457,
         first_name: "Robert",

--- a/test/controllers/caseload_controller_test.exs
+++ b/test/controllers/caseload_controller_test.exs
@@ -112,6 +112,9 @@ defmodule Healthlocker.CaseloadControllerTest do
       assert html_response(conn, 200) =~ "Caseload"
     end
   end
+
+  describe "current_user is assigned without epjs User_Guid" do
+    setup do
       %User{
         id: 123457,
         first_name: "Robert",
@@ -129,25 +132,17 @@ defmodule Healthlocker.CaseloadControllerTest do
         Staff_Name: "Robert MacMurray",
         Job_Title: "GP",
         Team_Member_Role_Desc: "Care team lead",
-        Email: "robert_macmurray@nhs.co.uk"
+        Email: "robert_macmurray@nhs.co.uk",
+        User_Guid: "someotherrandomstring"
       } |> ReadOnlyRepo.insert
-
-      %Room{
-        id: 1,
-        name: "service-user-care-team:123456"
-      } |> Repo.insert
-
-      %UserRoom{
-        user_id: 123456,
-        room_id: 1
-      } |> Repo.insert
 
       {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123457)) }
     end
 
-    test "GET /caseload", %{conn: conn} do
-      conn = get conn, caseload_path(conn, :index)
-      assert html_response(conn, 200) =~ "Caseload"
+    test "GET /caseload?=userData", %{conn: conn} do
+      conn = get conn, "/caseload?userData=UserName=robert_macmurray@nhs.co.uk&UserId=randomstringtotestwith&tokenexpiry=2017-06-23T11:15:53"
+      assert redirected_to(conn) == page_path(conn, :index)
+      assert get_flash(conn, :error) == "Authentication failed"
     end
   end
 end

--- a/test/features/caseload_users_test.exs
+++ b/test/features/caseload_users_test.exs
@@ -155,7 +155,20 @@ defmodule Healthlocker.CaseloadUsersTest do
     |> click(Query.link("Caseload"))
     |> click(Query.link("Tony Daly"))
     |> click(Query.link("Tracking"))
+    |> take_screenshot
 
     assert has_text?(session, "Tracking overview")
+  end
+
+  test "view goals and strategies", %{session: session} do
+    session
+    |> resize_window(768, 1024)
+    |> log_in("robert_macmurray@nhs.co.uk")
+    |> click(Query.link("Caseload"))
+    |> click(Query.link("Tony Daly"))
+    |> click(Query.link("Goals and strategies"))
+    |> take_screenshot
+
+    assert has_text?(session, "No goals yet created")
   end
 end

--- a/test/features/caseload_users_test.exs
+++ b/test/features/caseload_users_test.exs
@@ -75,7 +75,8 @@ defmodule Healthlocker.CaseloadUsersTest do
       Staff_Name: "Robert MacMurray",
       Job_Title: "GP",
       Team_Member_Role_Desc: "Care team lead",
-      Email: "robert_macmurray@nhs.co.uk"
+      Email: "robert_macmurray@nhs.co.uk",
+      User_Guid: "randomstring"
     } |> ReadOnlyRepo.insert
 
     %EPJSTeamMember{
@@ -84,7 +85,8 @@ defmodule Healthlocker.CaseloadUsersTest do
       Staff_Name: "Robert MacMurray",
       Job_Title: "GP",
       Team_Member_Role_Desc: "Care team lead",
-      Email: "robert_macmurray@nhs.co.uk"
+      Email: "robert_macmurray@nhs.co.uk",
+      User_Guid: "randomstring"
     } |> ReadOnlyRepo.insert
 
     Mix.Tasks.Healthlocker.Room.Create.run("run")
@@ -141,6 +143,7 @@ defmodule Healthlocker.CaseloadUsersTest do
     |> click(Query.link("Caseload"))
     |> click(Query.link("Jimmy Smits (friend/family/carer)"))
     |> click(Query.link("Details and contacts"))
+    |> take_screenshot
 
     assert session |> has_text?("Jimmy Smits")
   end

--- a/test/features/caseload_users_test.exs
+++ b/test/features/caseload_users_test.exs
@@ -65,7 +65,8 @@ defmodule Healthlocker.CaseloadUsersTest do
       security_question: "Name of first boss?",
       security_answer: "Betty",
       data_access: true,
-      role: "clinician"
+      role: "clinician",
+      user_guid: "randomstring"
     })
 
     %EPJSTeamMember{

--- a/test/features/clinician_message_test.exs
+++ b/test/features/clinician_message_test.exs
@@ -35,7 +35,8 @@ defmodule Healthlocker.ClinicianMessageTest do
       security_question: "Name of first boss?",
       security_answer: "Betty",
       data_access: true,
-      role: "clinician"
+      role: "clinician",
+      user_guid: "randomstring"
     })
     session |> log_in("robert_macmurray@nhs.co.uk")
 

--- a/web/controllers/caseload/room_controller.ex
+++ b/web/controllers/caseload/room_controller.ex
@@ -3,24 +3,30 @@ defmodule Healthlocker.Caseload.RoomController do
   use Healthlocker.Web, :controller
 
   def show(conn, %{"id" => id, "user_id" => user_id}) do
-    room = Repo.get((from r in Room, preload: [messages: :user]), id)
-    messages = Repo.all from m in Message,
+    if conn.assigns.current_user.user_guid do
+      room = Repo.get((from r in Room, preload: [messages: :user]), id)
+      messages = Repo.all from m in Message,
       where: m.room_id == ^room.id,
       order_by: [asc: :inserted_at, asc: :id],
       preload: [:user]
 
-    user = Repo.get!(User, user_id)
-    service_user = ServiceUser.for(user)
-    slam_user = ReadOnlyRepo.one(from e in EPJSUser,
-                where: e."Patient_ID" == ^service_user.slam_id)
+      user = Repo.get!(User, user_id)
+      service_user = ServiceUser.for(user)
+      slam_user = ReadOnlyRepo.one(from e in EPJSUser,
+      where: e."Patient_ID" == ^service_user.slam_id)
 
-    conn
-    |> assign(:service_user, service_user)
-    |> assign(:room, room)
-    |> assign(:messages, messages)
-    |> assign(:slam_user, slam_user)
-    |> assign(:user, user)
-    |> assign(:current_user_id, conn.assigns.current_user.id)
-    |> render("show.html")
+      conn
+      |> assign(:service_user, service_user)
+      |> assign(:room, room)
+      |> assign(:messages, messages)
+      |> assign(:slam_user, slam_user)
+      |> assign(:user, user)
+      |> assign(:current_user_id, conn.assigns.current_user.id)
+      |> render("show.html")
+    else
+      conn
+      |> put_flash(:error, "Authentication failed")
+      |> redirect(to: page_path(conn, :index))
+    end
   end
 end

--- a/web/controllers/caseload_controller.ex
+++ b/web/controllers/caseload_controller.ex
@@ -53,6 +53,8 @@ defmodule Healthlocker.CaseloadController do
         |> redirect(to: page_path(conn, :index))
     end
   end
+
+  def get_patients(clinician) do
     patient_ids = EPJSTeamMember
                   |> EPJSTeamMember.patient_ids(clinician.email)
                   |> ReadOnlyRepo.all
@@ -77,6 +79,6 @@ defmodule Healthlocker.CaseloadController do
                   user."Patient_ID" == hl.slam_id
                 end)
               end)
-    render(conn, "index.html", hl_users: hl_users, non_hl: non_hl)
+    %{hl_users: hl_users, non_hl: non_hl}
   end
 end

--- a/web/controllers/caseload_controller.ex
+++ b/web/controllers/caseload_controller.ex
@@ -1,7 +1,19 @@
 defmodule Healthlocker.CaseloadController do
   use Healthlocker.Web, :controller
 
-  alias Healthlocker.{EPJSTeamMember, EPJSUser, User}
+  alias Healthlocker.{EPJSTeamMember, EPJSUser, User, Plugs.Auth}
+
+  def index(conn, %{"userData" => user_data}) do
+    # decrypted_user_guid = decrypt_user_data(user_data)
+    decrypted_user_guid = "randomstringtotestwith"
+
+    case Repo.get_by(User, user_guid: decrypted_user_guid) do
+      nil ->
+        case ReadOnlyRepo.get_by(EPJSTeamMember, User_Guid: decrypted_user_guid) do
+          nil ->
+            conn
+            |> put_flash(:error, "Authentication failed")
+            |> redirect(to: page_path(conn, :index))
 
   def index(conn, _params) do
     clinician = conn.assigns.current_user

--- a/web/models/epjs_team_member.ex
+++ b/web/models/epjs_team_member.ex
@@ -8,6 +8,7 @@ defmodule Healthlocker.EPJSTeamMember do
     field :Job_Title, :string
     field :Team_Member_Role_Desc, :string
     field :Email, :string
+    field :User_Guid, :string
   end
 
   def changeset(struct, params \\ :invalid) do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -17,6 +17,7 @@ defmodule Healthlocker.User do
     field :comms_consent, :boolean
     field :role, :string
     field :slam_id, :integer
+    field :user_guid, :string
     field :reset_password_token, :string
     field :reset_token_sent_at, :utc_datetime
     has_many :posts, Healthlocker.Post

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -54,6 +54,14 @@ defmodule Healthlocker.User do
     name
     |> String.split(" ")
   end
+
+  def generate_random_password do
+    15
+    |> :crypto.strong_rand_bytes
+    |> Base.url_encode64
+    |> binary_part(0, 15)
+  end
+
   def update_changeset(struct, params \\ :invalid) do
     struct
     |> cast(params, [:email, :first_name, :last_name, :phone_number])

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -48,6 +48,12 @@ defmodule Healthlocker.User do
     this time, try again later or with different details.")
   end
 
+  def get_first_last_name(epjs_user) do
+    %{Staff_Name: name} = epjs_user
+
+    name
+    |> String.split(" ")
+  end
   def update_changeset(struct, params \\ :invalid) do
     struct
     |> cast(params, [:email, :first_name, :last_name, :phone_number])

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -48,6 +48,21 @@ defmodule Healthlocker.User do
     this time, try again later or with different details.")
   end
 
+  def clinician_changeset(struct, epjs_user) do
+    [first_name | last_name] = get_first_last_name(epjs_user)
+    struct
+    |> change(%{
+      email: epjs_user."Email",
+      first_name: first_name,
+      last_name: Enum.join(last_name, " "),
+      data_access: false,
+      role: "clinician",
+      user_guid: epjs_user."User_Guid",
+      password: generate_random_password()
+    })
+    |> put_pass_hash()
+  end
+
   def get_first_last_name(epjs_user) do
     %{Staff_Name: name} = epjs_user
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -52,7 +52,6 @@ defmodule Healthlocker.Router do
       resources "/contacts", ContactController, only: [:show], singleton: true
     end
 
-    resources "/caseload", CaseloadController, only: [:index]
     scope "/caseload", Caseload, as: :caseload do
       resources "/users", UserController, only: [:show] do
         resources "/rooms", RoomController, only: [:show]
@@ -88,5 +87,6 @@ defmodule Healthlocker.Router do
     resources "/tips", TipController, only: [:index]
     resources "/password", PasswordController, only: [:new, :create, :edit, :update]
     resources "/epjs-button", ButtonController, only: [:index]
+    resources "/caseload", CaseloadController, only: [:index]
   end
 end


### PR DESCRIPTION
Sets up clinician flow when arriving to healthlocker via caseload with `userData` param. #869 epic #838 
* Add user_guid to schemas
* Set up route for caseload index with userData param.
    * If user_guid does not exist in HL users & does exist in epjs, add clinician to HL, login, & display caseload
    * if user_guid exists in HL, log in clinician and display caseload
    * if user_guid does not exist in HL or epjs, redirect to homepage with flash message saying authentication failed
* Fixes and adds to relevant tests