### PR TITLE
stop clinician's from resetting passwords #912

### DIFF
--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -24,6 +24,10 @@ defmodule Healthlocker.PasswordController do
         conn
         |> put_flash(:error, "Could not send reset email. Please try again later")
         |> redirect(to: password_path(conn, :new))
+      %{role: "clinician"} ->
+        conn
+        |> put_flash(:error, "Could not send reset email. Please try again later")
+        |> redirect(to: password_path(conn, :new))
       user ->
         user = reset_password_token(user)
         # send password token to pw_params["email"]


### PR DESCRIPTION
add check to case statement to not allow clinician's to reset passwords #912.

@reddog at mindwave pointed out that this could be a security risk if clinicians can reset their passwords as someone may be able to gain access to the clinicians email, then log into HL and view sensitive patient info 