### PR TITLE
send longer messages in chat rooms 

### DIFF
--- a/lib/email.ex
+++ b/lib/email.ex
@@ -12,8 +12,8 @@ defmodule Healthlocker.Email do
   def send_reset_email(to_email, token) do
     new_email()
     |> to(to_email)
-    |> from("healthlocker.test@gmail.com")
+    |> from(System.get_env("FROM_EMAIL"))
     |> subject("Healthlocker Reset Password Instructions")
-    |> text_body("Please visit https://www.healthlocker.uk/password/#{token}/edit to reset your password")
+    |> text_body("Please visit https://staging.healthlocker.uk/password/#{token}/edit to reset your password")
   end
 end

--- a/priv/repo/migrations/20170713085039_edit_messages_table.exs
+++ b/priv/repo/migrations/20170713085039_edit_messages_table.exs
@@ -1,0 +1,9 @@
+defmodule Healthlocker.Repo.Migrations.EditMessagesTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      modify :body, :text
+    end
+  end
+end


### PR DESCRIPTION
create migration to edit messages table. This will allow for longer messages to be sent in chat rooms #880 