### PR TITLE
Add link to feedback on tips

### DIFF
--- a/web/templates/tip/index.html.eex
+++ b/web/templates/tip/index.html.eex
@@ -59,5 +59,5 @@
   <% end %>
 
   <p class="mt4"><%= link_to "Create a goal", to: "/goal/new"%> for yourself based on one of the 5 ways to wellbeing.</p>
-
+<p><%= link "Share your own tips, or suggest an addition or amendment to this page.", to: "/feedback", class: "hl-aqua flex-wrap underline" %></p>  
 </div>


### PR DESCRIPTION
As a HEALTHLOCKER user i want to see this link on both:
tips page: healthlocker.uk/tips
each tip tag page, e.g. healthlocker.uk/tips?tag=Connect

#903 