### PR TITLE
Fix plug

### DIFF
--- a/web/plugs/find_app_name.ex
+++ b/web/plugs/find_app_name.ex
@@ -8,19 +8,9 @@ defmodule Healthlocker.Plugs.AppName do
 
   def call(conn, _) do
     case Healthlocker.Endpoint.url() do
-      "http://localhost:4000"->
-        conn
-        |> assign(:app_name, "healthlocker")
-      "http://localhost:4001" ->
-        conn
-        |> assign(:app_name, "healthlocker")
-      "https://www.healthlocker.uk/" ->
-        conn
-        |> assign(:app_name, "healthlocker")
       _ ->
         conn
-        |> assign(:app_name, "oxleas")
-        |> Phoenix.Controller.put_layout({Healthlocker.Oxleas.LayoutView, "app.html"})
+        |> assign(:app_name, "healthlocker")
     end
   end
 


### PR DESCRIPTION
the plug wasn't working on the staging site since it was `https://staging.healthlocker.uk/`, which was not accounted for. Oxleas templates were loading for this & it was causing the site to crash. 

For now, this section is defaulted to set the `app_name` to healthlocker by default all the time.

#986