### PR TITLE
Restrict tracker

### DIFF
--- a/priv/repo/migrations/20171122100745_add_tracker_unique_index.exs
+++ b/priv/repo/migrations/20171122100745_add_tracker_unique_index.exs
@@ -1,0 +1,8 @@
+defmodule Healthlocker.Repo.Migrations.AddTrackerUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop index(:symptoms, [:user_id])
+    create unique_index(:symptoms, [:user_id])
+  end
+end

--- a/test/controllers/symptom_controller_test.exs
+++ b/test/controllers/symptom_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule Healthlocker.SymptomControllerTest do
   use Healthlocker.ConnCase
-  alias Healthlocker.User
+  alias Healthlocker.{User, Symptom}
 
   @valid_attrs %{symptom: "a problem"}
   @invalid_attrs %{symptom: ""}
@@ -31,6 +31,32 @@ defmodule Healthlocker.SymptomControllerTest do
     test "does not create symptom and renders errors when data is invalid", %{conn: conn} do
       conn = post conn, symptom_path(conn, :create), symptom: @invalid_attrs
       assert html_response(conn, 200) =~ "Problem tracker"
+    end
+  end
+
+  describe "current user assigned & symptom already inserted" do
+    setup do
+      %User{
+        id: 123456,
+        first_name: "My",
+        last_name: "Name",
+        email: "abc@gmail.com",
+        password_hash: Comeonin.Bcrypt.hashpwsalt("password")
+      } |> Repo.insert
+
+      %Symptom{
+        user_id: 123456,
+        symptom: "anger"
+      } |> Repo.insert
+
+      {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123456)) }
+    end
+
+    test "does not create duplicate problem", %{conn: conn} do
+      conn = post conn, symptom_path(conn, :create), symptom: @valid_attrs
+      assert html_response(conn, 200) =~ "Problem tracker"
+      error_flash = "You can only set up your problem tracker once. Track your problem now."
+      assert get_flash(conn, :error) == error_flash
     end
   end
 end

--- a/test/controllers/symptom_controller_test.exs
+++ b/test/controllers/symptom_controller_test.exs
@@ -52,6 +52,13 @@ defmodule Healthlocker.SymptomControllerTest do
       {:ok, conn: build_conn() |> assign(:current_user, Repo.get(User, 123456)) }
     end
 
+    test "/symptom/new redirects to /symptom_tracker/new when symptom exists", %{conn: conn} do
+      conn = get conn, symptom_path(conn, :new)
+      assert redirected_to(conn) == symptom_tracker_path(conn, :new)
+      error_flash = "You can only set up your problem tracker once. Track your problem now."
+      assert get_flash(conn, :error) == error_flash
+    end
+
     test "does not create duplicate problem", %{conn: conn} do
       conn = post conn, symptom_path(conn, :create), symptom: @valid_attrs
       assert html_response(conn, 200) =~ "Problem tracker"

--- a/web/controllers/symptom_controller.ex
+++ b/web/controllers/symptom_controller.ex
@@ -20,7 +20,7 @@ defmodule Healthlocker.SymptomController do
         |> redirect(to: symptom_tracker_path(conn, :new))
       {:error, changeset} ->
         conn
-        |> put_flash(:error, "You've already added a problem. Track it in the problem tracker.")
+        |> put_flash(:error, "You can only set up your problem tracker once. Track your problem now.")
         |> render("new.html", changeset: changeset)
     end
   end

--- a/web/controllers/symptom_controller.ex
+++ b/web/controllers/symptom_controller.ex
@@ -24,4 +24,8 @@ defmodule Healthlocker.SymptomController do
         |> render("new.html", changeset: changeset)
     end
   end
+
+  defp tracker_exists?(user_id) do
+    !!Repo.get_by(Symptom, user_id: user_id)
+  end
 end

--- a/web/controllers/symptom_controller.ex
+++ b/web/controllers/symptom_controller.ex
@@ -3,9 +3,15 @@ defmodule Healthlocker.SymptomController do
   alias Healthlocker.Symptom
 
   def new(conn, _params) do
-    changeset = Symptom.changeset(%Symptom{})
-    conn
-    |> render("new.html", changeset: changeset)
+    if tracker_exists?(conn.assigns.current_user.id) do
+      conn
+      |> put_flash(:error, "You can only set up your problem tracker once. Track your problem now." )
+      |> redirect(to: symptom_tracker_path(conn, :new))
+    else
+      changeset = Symptom.changeset(%Symptom{})
+      conn
+      |> render("new.html", changeset: changeset)
+    end
   end
 
   def create(conn, %{"symptom" => symptom}) do

--- a/web/controllers/symptom_controller.ex
+++ b/web/controllers/symptom_controller.ex
@@ -20,6 +20,7 @@ defmodule Healthlocker.SymptomController do
         |> redirect(to: symptom_tracker_path(conn, :new))
       {:error, changeset} ->
         conn
+        |> put_flash(:error, "You've already added a problem. Track it in the problem tracker.")
         |> render("new.html", changeset: changeset)
     end
   end

--- a/web/models/symptom.ex
+++ b/web/models/symptom.ex
@@ -12,6 +12,7 @@ defmodule Healthlocker.Symptom do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:symptom])
+    |> unique_constraint(:user_id)
     |> validate_required([:symptom])
   end
 end


### PR DESCRIPTION
restricts access to adding a new problem tracker when one is already created. #1109 